### PR TITLE
feat: add S3/cloud storage support for reading PCAPs

### DIFF
--- a/.github/workflows/cloud-integration.yml
+++ b/.github/workflows/cloud-integration.yml
@@ -1,0 +1,114 @@
+name: Cloud Integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Enable debug logging'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    services:
+      localstack:
+        image: localstack/localstack:latest
+        ports:
+          - 4566:4566
+        env:
+          SERVICES: s3
+          DEFAULT_REGION: us-east-1
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-cloud-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install AWS CLI
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip -q awscliv2.zip
+          sudo ./aws/install --update
+          aws --version
+
+      - name: Install compression tools
+        run: sudo apt-get update && sudo apt-get install -y zstd lz4
+
+      - name: Wait for LocalStack
+        run: |
+          echo "Waiting for LocalStack to be ready..."
+          for i in {1..30}; do
+            if curl -s http://localhost:4566/_localstack/health | grep -q '"s3": *"available"'; then
+              echo "LocalStack is ready!"
+              break
+            fi
+            echo "Waiting... ($i/30)"
+            sleep 2
+          done
+
+      - name: Generate and upload test data
+        env:
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          # Generate all test PCAP files using uvx
+          echo "Generating test PCAP files..."
+          uvx --with scapy python testdata/scripts/gen_format_tests.py --output-dir /tmp/generated
+
+          # Create test bucket
+          aws --endpoint-url=http://localhost:4566 s3 mb s3://test-pcaps
+
+          # Upload all generated PCAP files
+          echo "Uploading generated files..."
+          for f in /tmp/generated/*.pcap /tmp/generated/*.pcapng; do
+            if [ -f "$f" ]; then
+              aws --endpoint-url=http://localhost:4566 s3 cp "$f" "s3://test-pcaps/$(basename $f)"
+            fi
+          done
+
+          # Create compressed versions
+          echo "Creating compressed versions..."
+          gzip -c /tmp/generated/small_dns.pcap > /tmp/generated/small_dns.pcap.gz
+          zstd -q -c /tmp/generated/small_dns.pcap > /tmp/generated/small_dns.pcap.zst
+          lz4 -q -c /tmp/generated/small_dns.pcap > /tmp/generated/small_dns.pcap.lz4
+
+          # Upload compressed versions
+          aws --endpoint-url=http://localhost:4566 s3 cp /tmp/generated/small_dns.pcap.gz s3://test-pcaps/
+          aws --endpoint-url=http://localhost:4566 s3 cp /tmp/generated/small_dns.pcap.zst s3://test-pcaps/
+          aws --endpoint-url=http://localhost:4566 s3 cp /tmp/generated/small_dns.pcap.lz4 s3://test-pcaps/
+
+          # List uploaded files
+          echo "Uploaded files:"
+          aws --endpoint-url=http://localhost:4566 s3 ls s3://test-pcaps/
+
+      - name: Build with S3 and compression features
+        run: cargo build --features s3,compress-zstd,compress-lz4
+
+      - name: Run cloud integration tests
+        env:
+          RUST_BACKTRACE: ${{ inputs.debug && '1' || '0' }}
+        run: |
+          cargo test -p pcapsql-datafusion --features s3,compress-zstd,compress-lz4 \
+            --test cloud_integration -- --ignored --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,10 @@ netlink-packet-utils = "0.5"
 # SQLite database support
 rusqlite = { version = "0.31", features = ["bundled"] }
 
+# Cloud storage support (object_store for S3, GCS, Azure)
+object_store = "0.11"
+url = "2"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/pcapsql-core/Cargo.toml
+++ b/pcapsql-core/Cargo.toml
@@ -25,6 +25,13 @@ compress-bzip2 = ["dep:bzip2"]
 compress-xz = ["dep:xz2"]
 compress-all = ["compress-gzip", "compress-zstd", "compress-lz4", "compress-bzip2", "compress-xz"]
 
+# Cloud storage support
+cloud = ["dep:object_store", "dep:url", "dep:tokio"]
+s3 = ["cloud", "object_store/aws"]
+gcs = ["cloud", "object_store/gcp"]
+azure = ["cloud", "object_store/azure"]
+cloud-all = ["s3", "gcs", "azure"]
+
 [dependencies]
 # Parsing
 etherparse.workspace = true
@@ -42,6 +49,11 @@ xz2 = { workspace = true, optional = true }
 
 # Memory-mapped I/O (optional)
 memmap2 = { workspace = true, optional = true }
+
+# Cloud storage (optional)
+object_store = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
 
 # Error handling
 thiserror.workspace = true

--- a/pcapsql-core/src/io/cloud.rs
+++ b/pcapsql-core/src/io/cloud.rs
@@ -1,0 +1,979 @@
+//! Cloud storage reader implementation.
+//!
+//! Provides [`ObjectStoreReader`] which implements `std::io::Read` for cloud storage,
+//! enabling integration with the existing `GenericPcapReader<R: Read>` and
+//! `DecompressReader<R: Read>` abstractions.
+//!
+//! ## Supported Providers
+//!
+//! - AWS S3 (`s3://bucket/key`) - requires `s3` feature
+//! - Google Cloud Storage (`gs://bucket/key`) - requires `gcs` feature
+//! - Azure Blob Storage (`az://container/blob`) - requires `azure` feature
+//! - S3-compatible (MinIO, R2, LocalStack) - requires `s3` feature + custom endpoint
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use pcapsql_core::io::{CloudPacketSource, CloudLocation};
+//!
+//! let location = CloudLocation::parse("s3://bucket/capture.pcap")?;
+//! let source = CloudPacketSource::open(location).await?;
+//!
+//! // Now use with QueryEngine
+//! let engine = QueryEngine::with_streaming_source(source).await?;
+//! ```
+
+use std::io::{self, Read};
+use std::sync::Arc;
+
+use object_store::{path::Path as ObjectPath, ObjectStore};
+use url::Url;
+
+use crate::error::Error;
+
+/// Execute an async operation, handling runtime nesting correctly.
+///
+/// If called from within a tokio runtime, uses `block_in_place` to allow
+/// blocking while running the future on the current runtime's handle.
+/// If called outside a runtime, creates a temporary single-threaded runtime.
+fn run_async<F, T>(future: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    // Try to get the current runtime handle
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => {
+            // We're in a runtime, need to block in place and run on current handle
+            tokio::task::block_in_place(|| handle.block_on(future))
+        }
+        Err(_) => {
+            // Not in a runtime, create a temporary one
+            // Use current_thread to minimize overhead for blocking operations
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to create temporary runtime")
+                .block_on(future)
+        }
+    }
+}
+use crate::io::{
+    decompress_header, Compression, DecompressReader, GenericPcapReader, PacketPosition,
+    PacketRange, PacketReader, PacketRef, PacketSource, PacketSourceMetadata, PcapFormat,
+};
+
+/// Default chunk size for cloud reads (8MB).
+const DEFAULT_CHUNK_SIZE: usize = 8 * 1024 * 1024;
+
+/// Header size for initial read-ahead (64KB).
+/// This should be large enough to contain:
+/// - Compression magic bytes (up to 6 bytes)
+/// - PCAP file header (24 bytes for legacy, ~32 bytes for pcapng)
+/// - First few packet headers
+///
+/// We use 64KB to handle compressed files where the actual header
+/// may expand from compressed data.
+const HEADER_READ_SIZE: usize = 64 * 1024;
+
+/// Parsed cloud storage location.
+#[derive(Debug, Clone)]
+pub struct CloudLocation {
+    /// The parsed URL
+    url: Url,
+    /// Custom endpoint override (for S3-compatible services)
+    endpoint: Option<String>,
+    /// Whether to use anonymous (unsigned) requests
+    anonymous: bool,
+    /// Chunk size for byte-range requests
+    chunk_size: usize,
+}
+
+impl CloudLocation {
+    /// Parse a cloud storage URL.
+    ///
+    /// Supported formats:
+    /// - `s3://bucket/key` - AWS S3
+    /// - `gs://bucket/key` - Google Cloud Storage
+    /// - `az://container/blob` - Azure Blob Storage
+    /// - `s3://endpoint:port/bucket/key` - S3 with custom endpoint
+    pub fn parse(url_str: &str) -> Result<Self, Error> {
+        let url = Url::parse(url_str).map_err(|e| {
+            Error::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Invalid URL: {e}"),
+            ))
+        })?;
+
+        let scheme = url.scheme();
+        if !["s3", "gs", "az", "azure"].contains(&scheme) {
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Unsupported URL scheme: {scheme}. Expected s3://, gs://, or az://"),
+            )));
+        }
+
+        Ok(Self {
+            url,
+            endpoint: None,
+            anonymous: false,
+            chunk_size: DEFAULT_CHUNK_SIZE,
+        })
+    }
+
+    /// Set a custom endpoint URL (for MinIO, R2, LocalStack, etc.).
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = Some(endpoint.into());
+        self
+    }
+
+    /// Use anonymous (unsigned) requests for public buckets.
+    pub fn with_anonymous(mut self, anonymous: bool) -> Self {
+        self.anonymous = anonymous;
+        self
+    }
+
+    /// Set the chunk size for byte-range requests.
+    ///
+    /// Larger values reduce HTTP request overhead but increase memory usage.
+    /// Default is 8MB.
+    pub fn with_chunk_size(mut self, size: usize) -> Self {
+        self.chunk_size = size;
+        self
+    }
+
+    /// Get the configured chunk size.
+    pub fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
+
+    /// Get the URL scheme (s3, gs, az).
+    pub fn scheme(&self) -> &str {
+        self.url.scheme()
+    }
+
+    /// Get the bucket/container name.
+    pub fn bucket(&self) -> Option<&str> {
+        self.url.host_str()
+    }
+
+    /// Get the object key/path.
+    pub fn key(&self) -> &str {
+        self.url.path().trim_start_matches('/')
+    }
+
+    /// Get the custom endpoint if set.
+    pub fn endpoint(&self) -> Option<&str> {
+        self.endpoint.as_deref()
+    }
+
+    /// Check if anonymous access is enabled.
+    pub fn is_anonymous(&self) -> bool {
+        self.anonymous
+    }
+
+    /// Build an ObjectStore for this location.
+    pub fn build_store(&self) -> Result<Arc<dyn ObjectStore>, Error> {
+        match self.scheme() {
+            #[cfg(feature = "s3")]
+            "s3" => self.build_s3_store(),
+            #[cfg(feature = "gcs")]
+            "gs" => self.build_gcs_store(),
+            #[cfg(feature = "azure")]
+            "az" | "azure" => self.build_azure_store(),
+            scheme => Err(Error::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Unsupported or disabled scheme: {scheme}"),
+            ))),
+        }
+    }
+
+    #[cfg(feature = "s3")]
+    fn build_s3_store(&self) -> Result<Arc<dyn ObjectStore>, Error> {
+        use object_store::aws::AmazonS3Builder;
+
+        let bucket = self.bucket().ok_or_else(|| {
+            Error::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "S3 URL must include bucket name",
+            ))
+        })?;
+
+        let mut builder = AmazonS3Builder::from_env().with_bucket_name(bucket);
+
+        if let Some(endpoint) = &self.endpoint {
+            builder = builder.with_endpoint(endpoint).with_allow_http(true);
+        }
+
+        if self.anonymous {
+            builder = builder.with_skip_signature(true);
+        }
+
+        let store = builder
+            .build()
+            .map_err(|e| Error::Io(io::Error::other(format!("Failed to build S3 store: {e}"))))?;
+
+        Ok(Arc::new(store))
+    }
+
+    #[cfg(feature = "gcs")]
+    fn build_gcs_store(&self) -> Result<Arc<dyn ObjectStore>, Error> {
+        use object_store::gcp::GoogleCloudStorageBuilder;
+
+        let bucket = self.bucket().ok_or_else(|| {
+            Error::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "GCS URL must include bucket name",
+            ))
+        })?;
+
+        let mut builder = GoogleCloudStorageBuilder::from_env().with_bucket_name(bucket);
+
+        if self.anonymous {
+            builder = builder.with_anonymous(true);
+        }
+
+        let store = builder.build().map_err(|e| {
+            Error::Io(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to build GCS store: {e}"),
+            ))
+        })?;
+
+        Ok(Arc::new(store))
+    }
+
+    #[cfg(feature = "azure")]
+    fn build_azure_store(&self) -> Result<Arc<dyn ObjectStore>, Error> {
+        use object_store::azure::MicrosoftAzureBuilder;
+
+        let container = self.bucket().ok_or_else(|| {
+            Error::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Azure URL must include container name",
+            ))
+        })?;
+
+        let mut builder = MicrosoftAzureBuilder::from_env().with_container_name(container);
+
+        if self.anonymous {
+            builder = builder.with_skip_signature(true);
+        }
+
+        let store = builder.build().map_err(|e| {
+            Error::Io(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to build Azure store: {e}"),
+            ))
+        })?;
+
+        Ok(Arc::new(store))
+    }
+
+    /// Get the object path for this location.
+    pub fn object_path(&self) -> ObjectPath {
+        ObjectPath::from(self.key())
+    }
+}
+
+/// Cloud storage reader implementing `std::io::Read`.
+///
+/// Uses byte-range requests for efficient streaming. Data is fetched in chunks
+/// and buffered locally. This allows processing large cloud objects without
+/// downloading them entirely to memory.
+pub struct ObjectStoreReader {
+    store: Arc<dyn ObjectStore>,
+    path: ObjectPath,
+    object_size: u64,
+    position: u64,
+    buffer: Vec<u8>,
+    buffer_start: u64,
+    chunk_size: usize,
+}
+
+impl ObjectStoreReader {
+    /// Open a cloud object for reading.
+    pub fn open(location: &CloudLocation) -> Result<Self, Error> {
+        let store = location.build_store()?;
+        let path = location.object_path();
+
+        // Get object size via HEAD request
+        let object_size = run_async(async {
+            let meta = store.head(&path).await.map_err(|e| {
+                Error::Io(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("Failed to HEAD cloud object: {e}"),
+                ))
+            })?;
+            Ok::<u64, Error>(meta.size as u64)
+        })?;
+
+        Ok(Self {
+            store,
+            path,
+            object_size,
+            position: 0,
+            buffer: Vec::new(),
+            buffer_start: 0,
+            chunk_size: location.chunk_size(),
+        })
+    }
+
+    /// Create a reader with pre-fetched header bytes.
+    ///
+    /// This is an optimization to avoid re-fetching the header when the
+    /// caller has already fetched it for format detection.
+    pub fn with_prefetched_header(
+        store: Arc<dyn ObjectStore>,
+        path: ObjectPath,
+        object_size: u64,
+        chunk_size: usize,
+        header_bytes: Vec<u8>,
+    ) -> Self {
+        Self {
+            store,
+            path,
+            object_size,
+            position: 0,
+            buffer: header_bytes,
+            buffer_start: 0,
+            chunk_size,
+        }
+    }
+
+    /// Set the chunk size for fetching data.
+    pub fn with_chunk_size(mut self, size: usize) -> Self {
+        self.chunk_size = size;
+        self
+    }
+
+    /// Get the total size of the cloud object.
+    pub fn size(&self) -> u64 {
+        self.object_size
+    }
+
+    /// Fetch a range of bytes from the cloud object.
+    fn fetch_range(&self, start: u64, end: u64) -> io::Result<Vec<u8>> {
+        let store = Arc::clone(&self.store);
+        let path = self.path.clone();
+        run_async(async move {
+            let range = std::ops::Range {
+                start: start as usize,
+                end: end as usize,
+            };
+
+            let bytes = store
+                .get_range(&path, range)
+                .await
+                .map_err(|e| io::Error::other(format!("Cloud GetRange failed: {e}")))?;
+
+            Ok(bytes.to_vec())
+        })
+    }
+
+    /// Ensure buffer contains data at current position.
+    fn ensure_buffer(&mut self) -> io::Result<()> {
+        // Check if current position is within buffer
+        if self.position >= self.buffer_start
+            && self.position < self.buffer_start + self.buffer.len() as u64
+        {
+            return Ok(());
+        }
+
+        // Need to fetch new chunk
+        if self.position >= self.object_size {
+            // At EOF, clear buffer
+            self.buffer.clear();
+            return Ok(());
+        }
+
+        let start = self.position;
+        let end = (start + self.chunk_size as u64).min(self.object_size);
+
+        self.buffer = self.fetch_range(start, end)?;
+        self.buffer_start = start;
+
+        Ok(())
+    }
+}
+
+impl Read for ObjectStoreReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.position >= self.object_size {
+            return Ok(0); // EOF
+        }
+
+        self.ensure_buffer()?;
+
+        if self.buffer.is_empty() {
+            return Ok(0); // EOF
+        }
+
+        // Calculate how much we can read from buffer
+        let buffer_offset = (self.position - self.buffer_start) as usize;
+        let available = self.buffer.len() - buffer_offset;
+        let to_read = buf.len().min(available);
+
+        buf[..to_read].copy_from_slice(&self.buffer[buffer_offset..buffer_offset + to_read]);
+        self.position += to_read as u64;
+
+        Ok(to_read)
+    }
+}
+
+// ObjectStoreReader is Send because all its fields are Send
+unsafe impl Send for ObjectStoreReader {}
+
+// Required for async compatibility
+impl Unpin for ObjectStoreReader {}
+
+/// Cloud-backed packet source.
+///
+/// Implements [`PacketSource`] for cloud storage objects, enabling PCAP files
+/// stored in S3/GCS/Azure to be queried directly.
+#[derive(Clone)]
+pub struct CloudPacketSource {
+    location: CloudLocation,
+    metadata: PacketSourceMetadata,
+    compression: Compression,
+    pcap_format: PcapFormat,
+}
+
+impl CloudPacketSource {
+    /// Open a cloud object as a packet source.
+    ///
+    /// This method is optimized to minimize HTTP requests:
+    /// - 1 HEAD request to get object size
+    /// - 1 GET request for initial header (64KB)
+    /// - In-memory decompression and parsing (no additional requests)
+    ///
+    /// Can be called from both sync and async contexts - handles runtime
+    /// nesting correctly using `block_in_place` when called from async.
+    pub fn open(location: CloudLocation) -> Result<Self, Error> {
+        // Build object store
+        let store = location.build_store()?;
+        let path = location.object_path();
+
+        // 1. HEAD request to get object size
+        let store_clone = Arc::clone(&store);
+        let path_clone = path.clone();
+        let object_size = run_async(async move {
+            let meta = store_clone.head(&path_clone).await.map_err(|e| {
+                Error::Io(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("Failed to HEAD cloud object: {e}"),
+                ))
+            })?;
+            Ok::<u64, Error>(meta.size as u64)
+        })?;
+
+        if object_size < 24 {
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Cloud object too small to be a valid PCAP (< 24 bytes)",
+            )));
+        }
+
+        // 2. Single GET request for header (64KB or file size, whichever is smaller)
+        let header_size = HEADER_READ_SIZE.min(object_size as usize);
+        let store_clone = Arc::clone(&store);
+        let path_clone = path.clone();
+        let header_bytes = run_async(async move {
+            let range = std::ops::Range {
+                start: 0,
+                end: header_size,
+            };
+            let bytes = store_clone
+                .get_range(&path_clone, range)
+                .await
+                .map_err(|e| {
+                    Error::Io(io::Error::other(format!(
+                        "Failed to fetch cloud object header: {e}"
+                    )))
+                })?;
+            Ok::<Vec<u8>, Error>(bytes.to_vec())
+        })?;
+
+        if header_bytes.len() < 6 {
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Cloud object too small to be a valid PCAP",
+            )));
+        }
+
+        // 3. Detect compression from header bytes (in-memory, no HTTP)
+        let compression = Compression::detect(&header_bytes);
+
+        // 4. Get decompressed header for PCAP parsing (in-memory, no HTTP)
+        // Need at least 24 bytes for PCAP header, add margin for safety
+        const PCAP_HEADER_SIZE: usize = 256;
+        let decompressed_header = decompress_header(&header_bytes, compression, PCAP_HEADER_SIZE)
+            .map_err(|e| {
+            Error::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Failed to decompress header: {e}"),
+            ))
+        })?;
+
+        if decompressed_header.len() < 4 {
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Decompressed header too small for PCAP magic",
+            )));
+        }
+
+        // 5. Detect PCAP format from decompressed magic bytes
+        let pcap_magic = [
+            decompressed_header[0],
+            decompressed_header[1],
+            decompressed_header[2],
+            decompressed_header[3],
+        ];
+        let pcap_format = PcapFormat::detect(&pcap_magic)?;
+
+        // 6. Parse link type from decompressed header (in-memory, no HTTP)
+        let link_type = Self::parse_link_type_from_header(&decompressed_header, pcap_format)?;
+
+        let metadata = PacketSourceMetadata {
+            link_type,
+            snaplen: 65535,
+            size_bytes: Some(object_size),
+            packet_count: None, // Would require scanning
+            seekable: false,    // Cloud doesn't support efficient seeking
+        };
+
+        Ok(Self {
+            location,
+            metadata,
+            compression,
+            pcap_format,
+        })
+    }
+
+    /// Parse link type from decompressed PCAP header bytes.
+    fn parse_link_type_from_header(header: &[u8], format: PcapFormat) -> Result<u32, Error> {
+        if format.is_pcapng() {
+            // PCAPNG: Link type is in the Interface Description Block (IDB)
+            // which comes after the Section Header Block (SHB).
+            // Parse from the in-memory buffer using a cursor.
+            Self::parse_pcapng_link_type(header)
+        } else {
+            // Legacy PCAP file header structure:
+            // - Magic (4 bytes)
+            // - Version major (2 bytes)
+            // - Version minor (2 bytes)
+            // - Timezone (4 bytes)
+            // - Sigfigs (4 bytes)
+            // - Snaplen (4 bytes)
+            // - Link type (4 bytes)
+            // Total: 24 bytes
+            if header.len() < 24 {
+                return Err(Error::Io(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Header too small for link type: {} bytes (need 24)",
+                        header.len()
+                    ),
+                )));
+            }
+
+            // Link type is at offset 20, read as u32
+            let link_type = if format.is_little_endian() {
+                u32::from_le_bytes([header[20], header[21], header[22], header[23]])
+            } else {
+                u32::from_be_bytes([header[20], header[21], header[22], header[23]])
+            };
+
+            Ok(link_type)
+        }
+    }
+
+    /// Parse link type from PCAPNG header bytes.
+    ///
+    /// PCAPNG structure:
+    /// - Section Header Block (SHB): 28+ bytes
+    /// - Interface Description Block (IDB): contains link type at offset 8
+    fn parse_pcapng_link_type(header: &[u8]) -> Result<u32, Error> {
+        // Minimum size: SHB (28 bytes) + IDB header (12 bytes) = 40 bytes
+        if header.len() < 40 {
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Header too small for PCAPNG link type",
+            )));
+        }
+
+        // SHB structure:
+        // - Block Type (4): 0x0A0D0D0A
+        // - Block Total Length (4)
+        // - Byte-Order Magic (4): 0x1A2B3C4D
+        // - Major Version (2)
+        // - Minor Version (2)
+        // - Section Length (8)
+        // - Options (variable)
+        // - Block Total Length (4)
+
+        // Detect endianness from Byte-Order Magic at offset 8
+        let bom = u32::from_ne_bytes([header[8], header[9], header[10], header[11]]);
+        let is_le = bom == 0x1A2B3C4D;
+        let is_be = bom == 0x4D3C2B1A;
+
+        if !is_le && !is_be {
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Invalid PCAPNG byte-order magic: 0x{bom:08x}"),
+            )));
+        }
+
+        // Read SHB block total length to find where IDB starts
+        let shb_len = if is_le {
+            u32::from_le_bytes([header[4], header[5], header[6], header[7]])
+        } else {
+            u32::from_be_bytes([header[4], header[5], header[6], header[7]])
+        } as usize;
+
+        // IDB starts after SHB
+        let idb_start = shb_len;
+        if header.len() < idb_start + 12 {
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Header too small for IDB: {} bytes (need {})",
+                    header.len(),
+                    idb_start + 12
+                ),
+            )));
+        }
+
+        // Verify IDB block type (0x00000001)
+        let idb_type = if is_le {
+            u32::from_le_bytes([
+                header[idb_start],
+                header[idb_start + 1],
+                header[idb_start + 2],
+                header[idb_start + 3],
+            ])
+        } else {
+            u32::from_be_bytes([
+                header[idb_start],
+                header[idb_start + 1],
+                header[idb_start + 2],
+                header[idb_start + 3],
+            ])
+        };
+
+        if idb_type != 1 {
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Expected IDB block type 1, got {idb_type} at offset {idb_start}"),
+            )));
+        }
+
+        // IDB structure:
+        // - Block Type (4): 0x00000001
+        // - Block Total Length (4)
+        // - Link Type (2) <-- what we need
+        // - Reserved (2)
+        // - SnapLen (4)
+        // - Options (variable)
+        // - Block Total Length (4)
+
+        // Link type is at offset 8 within IDB (2 bytes)
+        let link_type = if is_le {
+            u16::from_le_bytes([header[idb_start + 8], header[idb_start + 9]]) as u32
+        } else {
+            u16::from_be_bytes([header[idb_start + 8], header[idb_start + 9]]) as u32
+        };
+
+        Ok(link_type)
+    }
+
+    /// Get the cloud location.
+    pub fn location(&self) -> &CloudLocation {
+        &self.location
+    }
+
+    /// Get the detected compression format.
+    pub fn compression(&self) -> Compression {
+        self.compression
+    }
+
+    /// Get the detected PCAP format.
+    pub fn pcap_format(&self) -> PcapFormat {
+        self.pcap_format
+    }
+}
+
+impl PacketSource for CloudPacketSource {
+    type Reader = CloudPacketReader;
+
+    fn metadata(&self) -> &PacketSourceMetadata {
+        &self.metadata
+    }
+
+    fn reader(&self, _range: Option<&PacketRange>) -> Result<Self::Reader, Error> {
+        // Note: Range support would require index or sequential scan
+        // For now, we always read from the beginning
+        CloudPacketReader::new(
+            &self.location,
+            self.compression,
+            self.pcap_format,
+            self.metadata.link_type,
+        )
+    }
+
+    fn partitions(&self, _max_partitions: usize) -> Result<Vec<PacketRange>, Error> {
+        // Cloud doesn't support efficient partitioning without an index
+        // Return single partition covering entire object
+        Ok(vec![PacketRange::whole()])
+    }
+}
+
+/// Cloud-backed packet reader.
+///
+/// Wraps the ObjectStoreReader → DecompressReader → GenericPcapReader stack
+/// and implements [`PacketReader`] for the query engine.
+pub struct CloudPacketReader {
+    inner: GenericPcapReader<DecompressReader<ObjectStoreReader>>,
+    link_type: u32,
+    position: PacketPosition,
+}
+
+impl CloudPacketReader {
+    /// Create a new cloud packet reader.
+    fn new(
+        location: &CloudLocation,
+        compression: Compression,
+        format: PcapFormat,
+        link_type: u32,
+    ) -> Result<Self, Error> {
+        let cloud_reader = ObjectStoreReader::open(location)?;
+        let decompress = DecompressReader::new(cloud_reader, compression)?;
+        let inner = GenericPcapReader::with_format(decompress, format)?;
+
+        Ok(Self {
+            inner,
+            link_type,
+            position: PacketPosition::START,
+        })
+    }
+}
+
+impl PacketReader for CloudPacketReader {
+    fn process_packets<F>(&mut self, max: usize, mut f: F) -> Result<usize, Error>
+    where
+        F: FnMut(PacketRef<'_>) -> Result<(), Error>,
+    {
+        let count = self.inner.process_packets(max, |packet| {
+            self.position.frame_number = packet.frame_number + 1;
+            f(packet)
+        })?;
+
+        Ok(count)
+    }
+
+    fn position(&self) -> PacketPosition {
+        self.position.clone()
+    }
+
+    fn link_type(&self) -> u32 {
+        self.link_type
+    }
+}
+
+// CloudPacketReader is Send
+unsafe impl Send for CloudPacketReader {}
+
+// Required for async compatibility
+impl Unpin for CloudPacketReader {}
+
+/// Check if a URL string is a cloud storage URL.
+pub fn is_cloud_url(url: &str) -> bool {
+    url.starts_with("s3://") || url.starts_with("gs://") || url.starts_with("az://")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_s3_url() {
+        let loc = CloudLocation::parse("s3://my-bucket/path/to/file.pcap").unwrap();
+        assert_eq!(loc.scheme(), "s3");
+        assert_eq!(loc.bucket(), Some("my-bucket"));
+        assert_eq!(loc.key(), "path/to/file.pcap");
+        assert!(loc.endpoint().is_none());
+    }
+
+    #[test]
+    fn test_parse_s3_root_key() {
+        let loc = CloudLocation::parse("s3://bucket/file.pcap").unwrap();
+        assert_eq!(loc.bucket(), Some("bucket"));
+        assert_eq!(loc.key(), "file.pcap");
+    }
+
+    #[test]
+    fn test_parse_gcs_url() {
+        let loc = CloudLocation::parse("gs://my-bucket/capture.pcap.gz").unwrap();
+        assert_eq!(loc.scheme(), "gs");
+        assert_eq!(loc.bucket(), Some("my-bucket"));
+        assert_eq!(loc.key(), "capture.pcap.gz");
+    }
+
+    #[test]
+    fn test_parse_azure_url() {
+        let loc = CloudLocation::parse("az://container/blob/path.pcap").unwrap();
+        assert_eq!(loc.scheme(), "az");
+        assert_eq!(loc.bucket(), Some("container"));
+        assert_eq!(loc.key(), "blob/path.pcap");
+    }
+
+    #[test]
+    fn test_parse_invalid_scheme() {
+        assert!(CloudLocation::parse("http://example.com/file").is_err());
+        assert!(CloudLocation::parse("ftp://bucket/key").is_err());
+    }
+
+    #[test]
+    fn test_with_endpoint() {
+        let loc = CloudLocation::parse("s3://bucket/key")
+            .unwrap()
+            .with_endpoint("http://localhost:9000");
+        assert_eq!(loc.endpoint(), Some("http://localhost:9000"));
+    }
+
+    #[test]
+    fn test_with_anonymous() {
+        let loc = CloudLocation::parse("s3://bucket/key")
+            .unwrap()
+            .with_anonymous(true);
+        assert!(loc.is_anonymous());
+    }
+
+    #[test]
+    fn test_is_cloud_url() {
+        assert!(is_cloud_url("s3://bucket/key"));
+        assert!(is_cloud_url("gs://bucket/key"));
+        assert!(is_cloud_url("az://container/blob"));
+        assert!(!is_cloud_url("/path/to/file.pcap"));
+        assert!(!is_cloud_url("./relative/path.pcap"));
+        assert!(!is_cloud_url("http://example.com"));
+    }
+
+    #[test]
+    fn test_object_path() {
+        let loc = CloudLocation::parse("s3://bucket/path/to/file.pcap").unwrap();
+        let path = loc.object_path();
+        assert_eq!(path.as_ref(), "path/to/file.pcap");
+    }
+
+    #[test]
+    fn test_with_chunk_size() {
+        let loc = CloudLocation::parse("s3://bucket/key")
+            .unwrap()
+            .with_chunk_size(16 * 1024 * 1024);
+        assert_eq!(loc.chunk_size(), 16 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_default_chunk_size() {
+        let loc = CloudLocation::parse("s3://bucket/key").unwrap();
+        assert_eq!(loc.chunk_size(), DEFAULT_CHUNK_SIZE);
+    }
+
+    #[test]
+    fn test_parse_legacy_link_type_le() {
+        // Legacy PCAP header with link type = 1 (Ethernet) at offset 20
+        // Little-endian format
+        let mut header = [0u8; 24];
+        // Magic (LE microseconds)
+        header[0..4].copy_from_slice(&[0xd4, 0xc3, 0xb2, 0xa1]);
+        // Version major
+        header[4..6].copy_from_slice(&[0x02, 0x00]);
+        // Version minor
+        header[6..8].copy_from_slice(&[0x04, 0x00]);
+        // Timezone (0)
+        // Sigfigs (0)
+        // Snaplen (65535)
+        header[16..20].copy_from_slice(&[0xff, 0xff, 0x00, 0x00]);
+        // Link type (1 = Ethernet, LE)
+        header[20..24].copy_from_slice(&[0x01, 0x00, 0x00, 0x00]);
+
+        let format = PcapFormat::LegacyLeMicro;
+        let link_type = CloudPacketSource::parse_link_type_from_header(&header, format).unwrap();
+        assert_eq!(link_type, 1);
+    }
+
+    #[test]
+    fn test_parse_legacy_link_type_be() {
+        // Legacy PCAP header with link type = 1 (Ethernet) at offset 20
+        // Big-endian format
+        let mut header = [0u8; 24];
+        // Magic (BE microseconds)
+        header[0..4].copy_from_slice(&[0xa1, 0xb2, 0xc3, 0xd4]);
+        // Version major
+        header[4..6].copy_from_slice(&[0x00, 0x02]);
+        // Version minor
+        header[6..8].copy_from_slice(&[0x00, 0x04]);
+        // Timezone (0)
+        // Sigfigs (0)
+        // Snaplen (65535)
+        header[16..20].copy_from_slice(&[0x00, 0x00, 0xff, 0xff]);
+        // Link type (1 = Ethernet, BE)
+        header[20..24].copy_from_slice(&[0x00, 0x00, 0x00, 0x01]);
+
+        let format = PcapFormat::LegacyBeMicro;
+        let link_type = CloudPacketSource::parse_link_type_from_header(&header, format).unwrap();
+        assert_eq!(link_type, 1);
+    }
+
+    #[test]
+    fn test_parse_pcapng_link_type() {
+        // Minimal PCAPNG with SHB (28 bytes) + IDB (20 bytes) = 48 bytes
+        let mut header = vec![0u8; 48];
+
+        // Section Header Block (SHB)
+        // Block Type (0x0A0D0D0A)
+        header[0..4].copy_from_slice(&[0x0a, 0x0d, 0x0d, 0x0a]);
+        // Block Total Length (28 bytes) - LE
+        header[4..8].copy_from_slice(&[0x1c, 0x00, 0x00, 0x00]);
+        // Byte-Order Magic (0x1A2B3C4D) - LE
+        header[8..12].copy_from_slice(&[0x4d, 0x3c, 0x2b, 0x1a]);
+        // Major Version (1)
+        header[12..14].copy_from_slice(&[0x01, 0x00]);
+        // Minor Version (0)
+        header[14..16].copy_from_slice(&[0x00, 0x00]);
+        // Section Length (-1 = unspecified)
+        header[16..24].copy_from_slice(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+        // Block Total Length (again)
+        header[24..28].copy_from_slice(&[0x1c, 0x00, 0x00, 0x00]);
+
+        // Interface Description Block (IDB) at offset 28
+        // Block Type (1)
+        header[28..32].copy_from_slice(&[0x01, 0x00, 0x00, 0x00]);
+        // Block Total Length (20 bytes)
+        header[32..36].copy_from_slice(&[0x14, 0x00, 0x00, 0x00]);
+        // Link Type (1 = Ethernet)
+        header[36..38].copy_from_slice(&[0x01, 0x00]);
+        // Reserved
+        header[38..40].copy_from_slice(&[0x00, 0x00]);
+        // SnapLen (65535)
+        header[40..44].copy_from_slice(&[0xff, 0xff, 0x00, 0x00]);
+        // Block Total Length (again)
+        header[44..48].copy_from_slice(&[0x14, 0x00, 0x00, 0x00]);
+
+        let link_type = CloudPacketSource::parse_pcapng_link_type(&header).unwrap();
+        assert_eq!(link_type, 1);
+    }
+
+    #[test]
+    fn test_parse_link_type_header_too_small() {
+        let header = [0u8; 20]; // Too small for legacy PCAP
+        let format = PcapFormat::LegacyLeMicro;
+        assert!(CloudPacketSource::parse_link_type_from_header(&header, format).is_err());
+    }
+
+    #[test]
+    fn test_parse_pcapng_header_too_small() {
+        let header = [0u8; 30]; // Too small for PCAPNG
+        assert!(CloudPacketSource::parse_pcapng_link_type(&header).is_err());
+    }
+}

--- a/pcapsql-core/src/io/mod.rs
+++ b/pcapsql-core/src/io/mod.rs
@@ -14,6 +14,7 @@
 //!
 //! - [`FilePacketSource`] - Standard buffered file I/O (works with all file types)
 //! - [`MmapPacketSource`] - Memory-mapped I/O for PCAP/PCAPNG files (requires `mmap` feature)
+//! - [`CloudPacketSource`] - Cloud storage I/O for S3, GCS, Azure (requires `cloud` feature)
 //!
 //! ## Compression Support
 //!
@@ -25,19 +26,26 @@
 //! - Bzip2 (.bz2) - `compress-bzip2` feature
 //! - XZ (.xz) - `compress-xz` feature
 
+#[cfg(feature = "cloud")]
+mod cloud;
 mod decompress;
 #[cfg(feature = "mmap")]
 mod mmap;
 mod pcap_stream;
 mod source;
 
+pub use decompress::{decompress_header, Compression, DecompressReader, FileDecoder};
 #[cfg(feature = "mmap")]
 pub use decompress::{AnyDecoder, MmapSlice};
-pub use decompress::{Compression, DecompressReader, FileDecoder};
 #[cfg(feature = "mmap")]
 pub use mmap::{MmapPacketReader, MmapPacketSource};
 pub use pcap_stream::{GenericPcapReader, PcapFormat};
 pub use source::{
     FilePacketReader, FilePacketSource, PacketPosition, PacketRange, PacketReader, PacketRef,
     PacketSource, PacketSourceMetadata, RawPacket,
+};
+
+#[cfg(feature = "cloud")]
+pub use cloud::{
+    is_cloud_url, CloudLocation, CloudPacketReader, CloudPacketSource, ObjectStoreReader,
 };

--- a/pcapsql-datafusion/Cargo.toml
+++ b/pcapsql-datafusion/Cargo.toml
@@ -25,6 +25,13 @@ compress-bzip2 = ["pcapsql-core/compress-bzip2"]
 compress-xz = ["pcapsql-core/compress-xz"]
 compress-all = ["pcapsql-core/compress-all"]
 
+# Cloud storage support
+cloud = ["pcapsql-core/cloud", "dep:url"]
+s3 = ["cloud", "pcapsql-core/s3"]
+gcs = ["cloud", "pcapsql-core/gcs"]
+azure = ["cloud", "pcapsql-core/azure"]
+cloud-all = ["s3", "gcs", "azure"]
+
 [dependencies]
 # Our core library
 pcapsql-core = { version = "0.2.0", path = "../pcapsql-core" }
@@ -66,12 +73,18 @@ rusqlite.workspace = true
 # BPF filter parsing
 nom.workspace = true
 
+# URL parsing for cloud storage detection
+url = { workspace = true, optional = true }
+
 [dev-dependencies]
 criterion.workspace = true
 tempfile.workspace = true
 hex.workspace = true
 smallvec.workspace = true
 compact_str.workspace = true
+
+# Cloud storage for integration tests
+pcapsql-core = { path = "../pcapsql-core", features = ["s3"] }
 
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/pcapsql-datafusion/src/cli/mod.rs
+++ b/pcapsql-datafusion/src/cli/mod.rs
@@ -5,15 +5,21 @@
 //! - Interactive REPL via rustyline
 //! - Output formatting (table, CSV, JSON)
 //! - Export functionality (Parquet, JSON, CSV, SQLite files)
+//! - URI handling and cloud storage detection
 
 mod args;
 mod export;
 mod output;
 mod repl;
 mod sqlite;
+mod uri;
 
 pub use args::{parse_size, Args, ExportFormat};
 pub use export::Exporter;
 pub use output::{OutputFormat, OutputFormatter};
 pub use repl::{Repl, ReplCommand, ReplInput};
 pub use sqlite::SqliteExporter;
+pub use uri::InputSource;
+
+#[cfg(feature = "cloud")]
+pub use uri::CloudOptions;

--- a/pcapsql-datafusion/src/cli/uri.rs
+++ b/pcapsql-datafusion/src/cli/uri.rs
@@ -1,0 +1,192 @@
+//! URI handling and cloud storage detection.
+//!
+//! This module provides utilities for:
+//! - Detecting cloud storage URLs (s3://, gs://, az://)
+//! - Creating appropriate packet sources based on URI scheme
+
+use std::path::PathBuf;
+
+/// Represents a parsed input source - either a local file or cloud URL.
+#[derive(Debug, Clone)]
+pub enum InputSource {
+    /// Local file path.
+    LocalFile(PathBuf),
+
+    /// Cloud storage URL (requires `cloud` feature).
+    #[cfg(feature = "cloud")]
+    CloudUrl(String),
+}
+
+impl InputSource {
+    /// Parse an input path or URL into an InputSource.
+    ///
+    /// Detects cloud URLs by scheme (s3://, gs://, az://) and falls back
+    /// to treating the input as a local file path.
+    pub fn parse(input: &str) -> Self {
+        #[cfg(feature = "cloud")]
+        {
+            if pcapsql_core::io::is_cloud_url(input) {
+                return InputSource::CloudUrl(input.to_string());
+            }
+        }
+
+        InputSource::LocalFile(PathBuf::from(input))
+    }
+
+    /// Check if this is a cloud URL.
+    #[allow(dead_code)]
+    pub fn is_cloud(&self) -> bool {
+        #[cfg(feature = "cloud")]
+        {
+            matches!(self, InputSource::CloudUrl(_))
+        }
+        #[cfg(not(feature = "cloud"))]
+        {
+            false
+        }
+    }
+
+    /// Get the display name for this source.
+    pub fn display_name(&self) -> String {
+        match self {
+            InputSource::LocalFile(path) => path.display().to_string(),
+            #[cfg(feature = "cloud")]
+            InputSource::CloudUrl(url) => url.clone(),
+        }
+    }
+}
+
+/// Cloud storage options parsed from CLI arguments.
+#[cfg(feature = "cloud")]
+#[derive(Debug, Clone, Default)]
+pub struct CloudOptions {
+    /// Custom endpoint URL (for S3-compatible services).
+    pub endpoint: Option<String>,
+
+    /// Use anonymous (unsigned) requests.
+    pub anonymous: bool,
+
+    /// Chunk size for byte-range requests.
+    pub chunk_size: usize,
+}
+
+#[cfg(feature = "cloud")]
+impl CloudOptions {
+    /// Create CloudOptions with defaults.
+    pub fn new() -> Self {
+        Self {
+            endpoint: None,
+            anonymous: false,
+            chunk_size: 8 * 1024 * 1024, // 8MB default
+        }
+    }
+
+    /// Set custom endpoint.
+    pub fn with_endpoint(mut self, endpoint: Option<String>) -> Self {
+        self.endpoint = endpoint;
+        self
+    }
+
+    /// Set anonymous mode.
+    pub fn with_anonymous(mut self, anonymous: bool) -> Self {
+        self.anonymous = anonymous;
+        self
+    }
+
+    /// Set chunk size.
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.chunk_size = chunk_size;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_local_file_parsing() {
+        let source = InputSource::parse("/path/to/file.pcap");
+        match source {
+            InputSource::LocalFile(path) => {
+                assert_eq!(path, PathBuf::from("/path/to/file.pcap"));
+            }
+            #[cfg(feature = "cloud")]
+            InputSource::CloudUrl(_) => panic!("Expected LocalFile"),
+        }
+    }
+
+    #[test]
+    fn test_relative_path_parsing() {
+        let source = InputSource::parse("./data/test.pcap");
+        match source {
+            InputSource::LocalFile(path) => {
+                assert_eq!(path, PathBuf::from("./data/test.pcap"));
+            }
+            #[cfg(feature = "cloud")]
+            InputSource::CloudUrl(_) => panic!("Expected LocalFile"),
+        }
+    }
+
+    #[cfg(feature = "cloud")]
+    #[test]
+    fn test_s3_url_parsing() {
+        let source = InputSource::parse("s3://bucket/key.pcap");
+        match source {
+            InputSource::CloudUrl(url) => {
+                assert_eq!(url, "s3://bucket/key.pcap");
+            }
+            InputSource::LocalFile(_) => panic!("Expected CloudUrl"),
+        }
+    }
+
+    #[cfg(feature = "cloud")]
+    #[test]
+    fn test_gs_url_parsing() {
+        let source = InputSource::parse("gs://bucket/path/to/file.pcap");
+        match source {
+            InputSource::CloudUrl(url) => {
+                assert_eq!(url, "gs://bucket/path/to/file.pcap");
+            }
+            InputSource::LocalFile(_) => panic!("Expected CloudUrl"),
+        }
+    }
+
+    #[cfg(feature = "cloud")]
+    #[test]
+    fn test_azure_url_parsing() {
+        let source = InputSource::parse("az://container/blob.pcap");
+        match source {
+            InputSource::CloudUrl(url) => {
+                assert_eq!(url, "az://container/blob.pcap");
+            }
+            InputSource::LocalFile(_) => panic!("Expected CloudUrl"),
+        }
+    }
+
+    #[test]
+    fn test_display_name_local() {
+        let source = InputSource::parse("test.pcap");
+        assert_eq!(source.display_name(), "test.pcap");
+    }
+
+    #[cfg(feature = "cloud")]
+    #[test]
+    fn test_display_name_cloud() {
+        let source = InputSource::parse("s3://bucket/file.pcap");
+        assert_eq!(source.display_name(), "s3://bucket/file.pcap");
+    }
+
+    #[cfg(feature = "cloud")]
+    #[test]
+    fn test_cloud_options_builder() {
+        let opts = CloudOptions::new()
+            .with_endpoint(Some("http://localhost:9000".to_string()))
+            .with_anonymous(true)
+            .with_chunk_size(16 * 1024 * 1024);
+
+        assert_eq!(opts.endpoint, Some("http://localhost:9000".to_string()));
+        assert!(opts.anonymous);
+        assert_eq!(opts.chunk_size, 16 * 1024 * 1024);
+    }
+}

--- a/pcapsql-datafusion/tests/cloud_integration.rs
+++ b/pcapsql-datafusion/tests/cloud_integration.rs
@@ -1,0 +1,557 @@
+//! Cloud storage integration tests.
+//!
+//! These tests require a running LocalStack or MinIO instance and are marked
+//! with `#[ignore]` so they don't run in normal CI. To run them:
+//!
+//! ```bash
+//! # Start LocalStack
+//! docker compose -f testdata/cloud/docker-compose.yml up -d
+//!
+//! # Generate and upload test data
+//! ./testdata/cloud/setup.sh
+//!
+//! # Run integration tests
+//! cargo test -p pcapsql-datafusion --features s3,compress-zstd,compress-lz4 \
+//!     --test cloud_integration -- --ignored
+//! ```
+//!
+//! All test files are generated dynamically by gen_format_tests.py.
+
+#[cfg(feature = "s3")]
+mod cloud_tests {
+    use pcapsql_core::io::{CloudLocation, CloudPacketSource, PacketReader, PacketSource};
+    use pcapsql_datafusion::query::QueryEngine;
+
+    /// LocalStack endpoint for S3-compatible testing.
+    const TEST_ENDPOINT: &str = "http://localhost:4566";
+
+    /// Test bucket name (created by setup.sh).
+    const TEST_BUCKET: &str = "test-pcaps";
+
+    // =========================================================================
+    // Basic connectivity tests (using generated small_dns.pcap)
+    // =========================================================================
+
+    #[test]
+    #[ignore]
+    fn test_s3_read_uncompressed_pcap() {
+        let url = format!("s3://{}/small_dns.pcap", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let source = CloudPacketSource::open(location).expect("Failed to open cloud source");
+        let meta = source.metadata();
+
+        assert!(meta.size_bytes.is_some());
+        assert!(meta.size_bytes.unwrap() > 0);
+        assert!(!meta.seekable); // Cloud sources are non-seekable
+        assert_eq!(meta.link_type, 1); // Ethernet
+    }
+
+    #[test]
+    #[ignore]
+    fn test_s3_not_found_returns_error() {
+        let url = format!("s3://{}/nonexistent.pcap", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let result = CloudPacketSource::open(location);
+        assert!(result.is_err());
+    }
+
+    // =========================================================================
+    // Packet reading tests
+    // =========================================================================
+
+    #[test]
+    #[ignore]
+    fn test_s3_read_packets() {
+        let url = format!("s3://{}/small_dns.pcap", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let source = CloudPacketSource::open(location).expect("Failed to open cloud source");
+        let mut reader = source.reader(None).expect("Failed to create reader");
+
+        let mut packet_count = 0;
+        loop {
+            let count = reader
+                .process_packets(100, |_packet| {
+                    packet_count += 1;
+                    Ok(())
+                })
+                .expect("Failed to process packets");
+
+            if count == 0 {
+                break;
+            }
+        }
+
+        // small_dns.pcap has 200 packets (100 queries + 100 responses)
+        assert_eq!(packet_count, 200, "Expected 200 DNS packets");
+    }
+
+    // =========================================================================
+    // Query engine integration tests (async - use QueryEngine)
+    // =========================================================================
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore]
+    async fn test_s3_query_with_cache() {
+        let url = format!("s3://{}/small_dns.pcap", TEST_BUCKET);
+
+        let engine = QueryEngine::with_cloud_source(
+            &url,
+            1000,  // batch_size
+            10000, // cache_size
+            Some(TEST_ENDPOINT),
+            true,            // anonymous
+            8 * 1024 * 1024, // chunk_size
+        )
+        .await
+        .expect("Failed to create QueryEngine");
+
+        // Simple count query
+        let result = engine
+            .query("SELECT COUNT(*) as cnt FROM frames")
+            .await
+            .expect("Query failed");
+
+        assert!(!result.is_empty());
+        let count: i64 = result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap()
+            .value(0);
+
+        assert_eq!(count, 200, "Should have 200 frames");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore]
+    async fn test_s3_streaming_join() {
+        let url = format!("s3://{}/small_dns.pcap", TEST_BUCKET);
+
+        let engine = QueryEngine::with_cloud_source(
+            &url,
+            1000,
+            10000,
+            Some(TEST_ENDPOINT),
+            true,
+            8 * 1024 * 1024,
+        )
+        .await
+        .expect("Failed to create QueryEngine");
+
+        // JOIN query across tables
+        let result = engine
+            .query(
+                "SELECT f.frame_number, d.query_name
+                 FROM frames f
+                 JOIN dns d ON f.frame_number = d.frame_number
+                 LIMIT 5",
+            )
+            .await
+            .expect("JOIN query failed");
+
+        assert!(!result.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore]
+    async fn test_s3_dns_query() {
+        let url = format!("s3://{}/small_dns.pcap", TEST_BUCKET);
+
+        let engine = QueryEngine::with_cloud_source(
+            &url,
+            1000,
+            10000,
+            Some(TEST_ENDPOINT),
+            true,
+            8 * 1024 * 1024,
+        )
+        .await
+        .expect("Failed to create QueryEngine");
+
+        // Query DNS table
+        let result = engine
+            .query("SELECT query_name, is_query FROM dns LIMIT 10")
+            .await
+            .expect("DNS query failed");
+
+        let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+        assert!(total_rows > 0, "DNS table should have rows");
+    }
+
+    // =========================================================================
+    // Edge case tests
+    // =========================================================================
+
+    #[test]
+    #[ignore]
+    fn test_s3_small_chunk_size() {
+        // Test with very small chunk size to exercise buffering
+        let url = format!("s3://{}/small_dns.pcap", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true)
+            .with_chunk_size(1024); // 1KB chunks
+
+        let source = CloudPacketSource::open(location).expect("Failed to open cloud source");
+        let mut reader = source.reader(None).expect("Failed to create reader");
+
+        let mut packet_count = 0;
+        loop {
+            let count = reader
+                .process_packets(10, |_| {
+                    packet_count += 1;
+                    Ok(())
+                })
+                .expect("Failed to process packets");
+
+            if count == 0 {
+                break;
+            }
+        }
+
+        assert_eq!(
+            packet_count, 200,
+            "Should read all 200 packets with small chunks"
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn test_s3_partitions_returns_single() {
+        let url = format!("s3://{}/small_dns.pcap", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let source = CloudPacketSource::open(location).expect("Failed to open cloud source");
+        let partitions = source.partitions(4).expect("Failed to get partitions");
+
+        // Cloud sources should return a single partition
+        assert_eq!(partitions.len(), 1);
+    }
+
+    // =========================================================================
+    // Large file tests (chunk boundary crossing)
+    // =========================================================================
+
+    #[test]
+    #[ignore]
+    fn test_s3_large_file_chunk_boundary() {
+        // large_10mb.pcap is >8MB, default chunk is 8MB
+        // This tests reading across multiple chunks
+        let url = format!("s3://{}/large_10mb.pcap", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let source = CloudPacketSource::open(location).expect("Failed to open cloud source");
+        let meta = source.metadata();
+
+        // Verify file size (large_10mb.pcap is ~6.3MB in practice)
+        assert!(
+            meta.size_bytes.unwrap() > 5 * 1024 * 1024,
+            "Large file should be >5MB, got {} bytes",
+            meta.size_bytes.unwrap()
+        );
+
+        let mut reader = source.reader(None).expect("Failed to create reader");
+
+        let mut packet_count = 0;
+        loop {
+            let count = reader
+                .process_packets(1000, |_| {
+                    packet_count += 1;
+                    Ok(())
+                })
+                .expect("Failed to process packets");
+
+            if count == 0 {
+                break;
+            }
+        }
+
+        // large_10mb.pcap has 65536 packets
+        assert!(
+            packet_count > 50000,
+            "Expected many packets from large file, got {}",
+            packet_count
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore]
+    async fn test_s3_large_file_query() {
+        let url = format!("s3://{}/large_10mb.pcap", TEST_BUCKET);
+
+        let engine = QueryEngine::with_cloud_source(
+            &url,
+            1000,
+            50000, // Larger cache for big file
+            Some(TEST_ENDPOINT),
+            true,
+            8 * 1024 * 1024,
+        )
+        .await
+        .expect("Failed to create QueryEngine");
+
+        let result = engine
+            .query("SELECT COUNT(*) FROM frames")
+            .await
+            .expect("Query failed");
+
+        let count: i64 = result[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap()
+            .value(0);
+
+        assert!(count > 50000, "Expected many frames from large file");
+    }
+
+    // =========================================================================
+    // Format variant tests
+    // =========================================================================
+
+    #[test]
+    #[ignore]
+    fn test_s3_pcapng_format() {
+        let url = format!("s3://{}/format_pcapng.pcapng", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let source = CloudPacketSource::open(location).expect("Failed to open PCAPNG source");
+        let meta = source.metadata();
+
+        // Verify PCAPNG was detected and link type parsed
+        assert_eq!(meta.link_type, 1, "PCAPNG should have Ethernet link type");
+
+        // Read and count packets
+        let mut reader = source.reader(None).expect("Failed to create reader");
+        let mut packet_count = 0;
+        loop {
+            let count = reader
+                .process_packets(100, |_| {
+                    packet_count += 1;
+                    Ok(())
+                })
+                .expect("Failed to process packets");
+            if count == 0 {
+                break;
+            }
+        }
+        assert_eq!(packet_count, 200, "PCAPNG should have 200 packets");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_s3_legacy_be_micro_format() {
+        let url = format!("s3://{}/format_be_micro.pcap", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let source = CloudPacketSource::open(location).expect("Failed to open BE micro source");
+        let meta = source.metadata();
+
+        assert_eq!(meta.link_type, 1, "BE micro should have Ethernet link type");
+
+        let mut reader = source.reader(None).expect("Failed to create reader");
+        let mut packet_count = 0;
+        loop {
+            let count = reader
+                .process_packets(100, |_| {
+                    packet_count += 1;
+                    Ok(())
+                })
+                .expect("Failed to process packets");
+            if count == 0 {
+                break;
+            }
+        }
+        assert_eq!(packet_count, 200, "BE micro should have 200 packets");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_s3_legacy_le_nano_format() {
+        let url = format!("s3://{}/format_le_nano.pcap", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let source = CloudPacketSource::open(location).expect("Failed to open LE nano source");
+        let meta = source.metadata();
+
+        assert_eq!(meta.link_type, 1, "LE nano should have Ethernet link type");
+
+        let mut reader = source.reader(None).expect("Failed to create reader");
+        let mut packet_count = 0;
+        loop {
+            let count = reader
+                .process_packets(100, |_| {
+                    packet_count += 1;
+                    Ok(())
+                })
+                .expect("Failed to process packets");
+            if count == 0 {
+                break;
+            }
+        }
+        assert_eq!(packet_count, 200, "LE nano should have 200 packets");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_s3_legacy_be_nano_format() {
+        let url = format!("s3://{}/format_be_nano.pcap", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let source = CloudPacketSource::open(location).expect("Failed to open BE nano source");
+        let meta = source.metadata();
+
+        assert_eq!(meta.link_type, 1, "BE nano should have Ethernet link type");
+
+        let mut reader = source.reader(None).expect("Failed to create reader");
+        let mut packet_count = 0;
+        loop {
+            let count = reader
+                .process_packets(100, |_| {
+                    packet_count += 1;
+                    Ok(())
+                })
+                .expect("Failed to process packets");
+            if count == 0 {
+                break;
+            }
+        }
+        assert_eq!(packet_count, 200, "BE nano should have 200 packets");
+    }
+
+    // =========================================================================
+    // Compression tests
+    // =========================================================================
+
+    #[test]
+    #[ignore]
+    fn test_s3_gzip_compression() {
+        let url = format!("s3://{}/small_dns.pcap.gz", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let source = CloudPacketSource::open(location).expect("Failed to open gzip source");
+        let meta = source.metadata();
+
+        assert_eq!(meta.link_type, 1, "Gzip should detect Ethernet link type");
+
+        let mut reader = source.reader(None).expect("Failed to create reader");
+        let mut packet_count = 0;
+        loop {
+            let count = reader
+                .process_packets(100, |_| {
+                    packet_count += 1;
+                    Ok(())
+                })
+                .expect("Failed to process packets");
+            if count == 0 {
+                break;
+            }
+        }
+        assert_eq!(
+            packet_count, 200,
+            "Gzip compressed file should have 200 packets"
+        );
+    }
+
+    #[cfg(feature = "compress-zstd")]
+    #[test]
+    #[ignore]
+    fn test_s3_zstd_compression() {
+        let url = format!("s3://{}/small_dns.pcap.zst", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let source = CloudPacketSource::open(location).expect("Failed to open zstd source");
+        let meta = source.metadata();
+
+        assert_eq!(meta.link_type, 1, "Zstd should detect Ethernet link type");
+
+        let mut reader = source.reader(None).expect("Failed to create reader");
+        let mut packet_count = 0;
+        loop {
+            let count = reader
+                .process_packets(100, |_| {
+                    packet_count += 1;
+                    Ok(())
+                })
+                .expect("Failed to process packets");
+            if count == 0 {
+                break;
+            }
+        }
+        assert_eq!(
+            packet_count, 200,
+            "Zstd compressed file should have 200 packets"
+        );
+    }
+
+    #[cfg(feature = "compress-lz4")]
+    #[test]
+    #[ignore]
+    fn test_s3_lz4_compression() {
+        let url = format!("s3://{}/small_dns.pcap.lz4", TEST_BUCKET);
+        let location = CloudLocation::parse(&url)
+            .expect("Failed to parse URL")
+            .with_endpoint(TEST_ENDPOINT)
+            .with_anonymous(true);
+
+        let source = CloudPacketSource::open(location).expect("Failed to open lz4 source");
+        let meta = source.metadata();
+
+        assert_eq!(meta.link_type, 1, "LZ4 should detect Ethernet link type");
+
+        let mut reader = source.reader(None).expect("Failed to create reader");
+        let mut packet_count = 0;
+        loop {
+            let count = reader
+                .process_packets(100, |_| {
+                    packet_count += 1;
+                    Ok(())
+                })
+                .expect("Failed to process packets");
+            if count == 0 {
+                break;
+            }
+        }
+        assert_eq!(
+            packet_count, 200,
+            "LZ4 compressed file should have 200 packets"
+        );
+    }
+}

--- a/testdata/cloud/docker-compose.yml
+++ b/testdata/cloud/docker-compose.yml
@@ -1,0 +1,29 @@
+# LocalStack configuration for S3 integration testing
+#
+# Usage:
+#   docker compose up -d      # Start LocalStack
+#   ./setup.sh                # Upload test data
+#   docker compose down       # Stop LocalStack
+#
+# Then run integration tests:
+#   cargo test --features s3 --test cloud_integration -- --ignored
+
+services:
+  localstack:
+    image: localstack/localstack:latest
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=s3
+      - DEFAULT_REGION=us-east-1
+      - DEBUG=0
+    volumes:
+      - localstack_data:/var/lib/localstack
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  localstack_data:

--- a/testdata/cloud/setup.sh
+++ b/testdata/cloud/setup.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Generate and upload test PCAP files to LocalStack S3 for integration testing.
+#
+# This script generates ALL test files dynamically - no binary files in git.
+#
+# Prerequisites:
+#   - LocalStack running (docker compose up -d)
+#   - AWS CLI installed (or awslocal)
+#   - uvx (for Python dependency management)
+#   - compression tools: gzip, zstd, lz4
+#
+# Usage:
+#   ./setup.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENDPOINT="http://localhost:4566"
+BUCKET="test-pcaps"
+REGION="us-east-1"
+OUTPUT_DIR="/tmp/generated"
+
+# Use awslocal if available, otherwise aws with endpoint override
+if command -v awslocal &> /dev/null; then
+    AWS="awslocal"
+else
+    AWS="aws --endpoint-url=$ENDPOINT --region=$REGION"
+fi
+
+echo "=== Step 1: Generate test PCAP files ==="
+echo "Using uvx to run generator with scapy..."
+
+# Generate all test files
+uvx --with scapy python "$SCRIPT_DIR/../scripts/gen_format_tests.py" --output-dir "$OUTPUT_DIR"
+
+echo ""
+echo "=== Step 2: Wait for LocalStack ==="
+echo "Waiting for LocalStack to be ready..."
+until curl -s "$ENDPOINT/_localstack/health" | grep -q '"s3": *"available"'; do
+    sleep 1
+done
+echo "LocalStack is ready!"
+
+echo ""
+echo "=== Step 3: Create S3 bucket ==="
+$AWS s3 mb "s3://$BUCKET" 2>/dev/null || echo "Bucket already exists"
+
+echo ""
+echo "=== Step 4: Upload generated PCAP files ==="
+for f in "$OUTPUT_DIR"/*.pcap "$OUTPUT_DIR"/*.pcapng; do
+    if [ -f "$f" ]; then
+        echo "Uploading $(basename "$f")..."
+        $AWS s3 cp "$f" "s3://$BUCKET/$(basename "$f")"
+    fi
+done
+
+echo ""
+echo "=== Step 5: Create and upload compressed versions ==="
+# Use small_dns.pcap as the base for compression tests
+if [ -f "$OUTPUT_DIR/small_dns.pcap" ]; then
+    echo "Creating gzip compressed version..."
+    gzip -c "$OUTPUT_DIR/small_dns.pcap" > "$OUTPUT_DIR/small_dns.pcap.gz"
+    $AWS s3 cp "$OUTPUT_DIR/small_dns.pcap.gz" "s3://$BUCKET/"
+
+    if command -v zstd &> /dev/null; then
+        echo "Creating zstd compressed version..."
+        zstd -q -c "$OUTPUT_DIR/small_dns.pcap" > "$OUTPUT_DIR/small_dns.pcap.zst"
+        $AWS s3 cp "$OUTPUT_DIR/small_dns.pcap.zst" "s3://$BUCKET/"
+    else
+        echo "Warning: zstd not installed, skipping zstd compression test"
+    fi
+
+    if command -v lz4 &> /dev/null; then
+        echo "Creating lz4 compressed version..."
+        lz4 -q -c "$OUTPUT_DIR/small_dns.pcap" > "$OUTPUT_DIR/small_dns.pcap.lz4"
+        $AWS s3 cp "$OUTPUT_DIR/small_dns.pcap.lz4" "s3://$BUCKET/"
+    else
+        echo "Warning: lz4 not installed, skipping lz4 compression test"
+    fi
+fi
+
+echo ""
+echo "=== Uploaded files ==="
+$AWS s3 ls "s3://$BUCKET/"
+
+echo ""
+echo "=== Setup complete! ==="
+echo "Run integration tests with:"
+echo "  cargo test -p pcapsql-datafusion --features s3 --test cloud_integration -- --ignored"

--- a/testdata/scripts/gen_format_tests.py
+++ b/testdata/scripts/gen_format_tests.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+Generate test PCAP files in all supported formats for cloud integration testing.
+
+This script generates PCAP files in all 5 formats that pcapsql supports:
+- Legacy little-endian microseconds (default)
+- Legacy big-endian microseconds
+- Legacy little-endian nanoseconds
+- Legacy big-endian nanoseconds
+- PCAPNG
+
+Usage:
+    uvx --with scapy python gen_format_tests.py --output-dir /tmp/generated
+"""
+
+import argparse
+import os
+import struct
+import time
+from pathlib import Path
+
+# Scapy imports
+from scapy.all import Ether, IP, UDP, DNS, DNSQR, Raw, wrpcap
+from scapy.utils import PcapNgWriter
+
+
+# PCAP magic numbers - the same magic is written in different byte orders
+# The magic value 0xa1b2c3d4 means microseconds, 0xa1b23c4d means nanoseconds
+# LE files write LSB first, BE files write MSB first
+PCAP_MAGIC_MICRO = 0xA1B2C3D4  # Microsecond timestamp magic
+PCAP_MAGIC_NANO = 0xA1B23C4D   # Nanosecond timestamp magic
+
+# Link type for Ethernet
+LINKTYPE_ETHERNET = 1
+
+# PCAP header constants
+PCAP_VERSION_MAJOR = 2
+PCAP_VERSION_MINOR = 4
+PCAP_SNAPLEN = 65535
+
+
+def generate_dns_packets(count: int = 100) -> list:
+    """Generate DNS query/response packets."""
+    packets = []
+    base_time = time.time()
+
+    for i in range(count):
+        # Vary source port and transaction ID
+        sport = 10000 + (i % 55535)
+        txid = i % 65536
+
+        # DNS query packet
+        query = (
+            Ether(src="00:11:22:33:44:55", dst="66:77:88:99:aa:bb") /
+            IP(src="192.168.1.100", dst="8.8.8.8") /
+            UDP(sport=sport, dport=53) /
+            DNS(id=txid, qr=0, qd=DNSQR(qname=f"test{i}.example.com"))
+        )
+        query.time = base_time + (i * 0.001)  # 1ms apart
+        packets.append(query)
+
+        # DNS response packet
+        response = (
+            Ether(src="66:77:88:99:aa:bb", dst="00:11:22:33:44:55") /
+            IP(src="8.8.8.8", dst="192.168.1.100") /
+            UDP(sport=53, dport=sport) /
+            DNS(id=txid, qr=1, qd=DNSQR(qname=f"test{i}.example.com"))
+        )
+        response.time = base_time + (i * 0.001) + 0.0005
+        packets.append(response)
+
+    return packets
+
+
+def generate_large_packets(target_size_mb: int = 10) -> list:
+    """Generate enough packets to exceed the target size."""
+    packets = []
+    base_time = time.time()
+
+    # Each packet is roughly 100-150 bytes
+    # To get 10MB, we need about 100K packets
+    packet_count = (target_size_mb * 1024 * 1024) // 120
+
+    print(f"Generating {packet_count} packets for {target_size_mb}MB file...")
+
+    for i in range(packet_count):
+        # Simple UDP packet with some payload
+        pkt = (
+            Ether(src="00:11:22:33:44:55", dst="66:77:88:99:aa:bb") /
+            IP(src=f"10.0.{(i >> 8) & 0xff}.{i & 0xff}", dst="10.0.0.1") /
+            UDP(sport=12345, dport=80) /
+            Raw(load=f"packet-{i:08d}")
+        )
+        pkt.time = base_time + (i * 0.0001)
+        packets.append(pkt)
+
+        if (i + 1) % 10000 == 0:
+            print(f"  Generated {i + 1}/{packet_count} packets...")
+
+    return packets
+
+
+def write_legacy_pcap(packets: list, filename: str, big_endian: bool = False, nano: bool = False):
+    """
+    Write packets to a legacy PCAP file with specified byte order.
+
+    Args:
+        packets: List of scapy packets
+        filename: Output filename
+        big_endian: If True, write in big-endian byte order
+        nano: If True, use nanosecond timestamps instead of microseconds
+    """
+    endian = ">" if big_endian else "<"
+    magic = PCAP_MAGIC_NANO if nano else PCAP_MAGIC_MICRO
+
+    with open(filename, "wb") as f:
+        # Write global header (24 bytes)
+        # magic (4) + version_major (2) + version_minor (2) + thiszone (4) +
+        # sigfigs (4) + snaplen (4) + network (4)
+        header = struct.pack(
+            f"{endian}IHHiIII",
+            magic,
+            PCAP_VERSION_MAJOR,
+            PCAP_VERSION_MINOR,
+            0,  # thiszone (GMT offset)
+            0,  # sigfigs (timestamp accuracy)
+            PCAP_SNAPLEN,
+            LINKTYPE_ETHERNET
+        )
+        f.write(header)
+
+        # Write each packet
+        for pkt in packets:
+            pkt_bytes = bytes(pkt)
+            pkt_len = len(pkt_bytes)
+
+            # Get timestamp
+            ts = float(pkt.time) if hasattr(pkt, 'time') else time.time()
+            ts_sec = int(ts)
+            if nano:
+                ts_subsec = int((ts - ts_sec) * 1_000_000_000)  # nanoseconds
+            else:
+                ts_subsec = int((ts - ts_sec) * 1_000_000)  # microseconds
+
+            # Packet header: ts_sec (4) + ts_usec/nsec (4) + incl_len (4) + orig_len (4)
+            pkt_header = struct.pack(
+                f"{endian}IIII",
+                ts_sec,
+                ts_subsec,
+                pkt_len,  # captured length
+                pkt_len   # original length
+            )
+            f.write(pkt_header)
+            f.write(pkt_bytes)
+
+
+def write_le_micro(packets: list, filename: str):
+    """Write legacy PCAP with little-endian byte order, microsecond timestamps."""
+    write_legacy_pcap(packets, filename, big_endian=False, nano=False)
+
+
+def write_be_micro(packets: list, filename: str):
+    """Write legacy PCAP with big-endian byte order, microsecond timestamps."""
+    write_legacy_pcap(packets, filename, big_endian=True, nano=False)
+
+
+def write_le_nano(packets: list, filename: str):
+    """Write legacy PCAP with little-endian byte order, nanosecond timestamps."""
+    write_legacy_pcap(packets, filename, big_endian=False, nano=True)
+
+
+def write_be_nano(packets: list, filename: str):
+    """Write legacy PCAP with big-endian byte order, nanosecond timestamps."""
+    write_legacy_pcap(packets, filename, big_endian=True, nano=True)
+
+
+def write_pcapng(packets: list, filename: str):
+    """Write packets to PCAPNG format."""
+    writer = PcapNgWriter(filename)
+    for pkt in packets:
+        writer.write(pkt)
+    writer.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate test PCAP files in all supported formats"
+    )
+    parser.add_argument(
+        "--output-dir", "-o",
+        type=str,
+        default="/tmp/generated",
+        help="Output directory for generated files"
+    )
+    parser.add_argument(
+        "--large-size",
+        type=int,
+        default=10,
+        help="Size of large test file in MB (default: 10)"
+    )
+    parser.add_argument(
+        "--small-count",
+        type=int,
+        default=100,
+        help="Number of DNS packets for small files (default: 100)"
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Output directory: {output_dir}")
+
+    # Generate small DNS packets for format testing
+    print("\nGenerating small DNS packets...")
+    small_packets = generate_dns_packets(args.small_count)
+
+    # Write small files in each format
+    print("\nWriting format test files...")
+
+    # 1. Small DNS file (for basic tests and compression source)
+    small_dns_file = output_dir / "small_dns.pcap"
+    write_le_micro(small_packets, str(small_dns_file))
+    print(f"  Created: {small_dns_file} ({small_dns_file.stat().st_size} bytes)")
+
+    # 2. Legacy LE Micro
+    le_micro_file = output_dir / "format_le_micro.pcap"
+    write_le_micro(small_packets, str(le_micro_file))
+    print(f"  Created: {le_micro_file} ({le_micro_file.stat().st_size} bytes)")
+
+    # 3. Legacy BE Micro
+    be_micro_file = output_dir / "format_be_micro.pcap"
+    write_be_micro(small_packets, str(be_micro_file))
+    print(f"  Created: {be_micro_file} ({be_micro_file.stat().st_size} bytes)")
+
+    # 4. Legacy LE Nano
+    le_nano_file = output_dir / "format_le_nano.pcap"
+    write_le_nano(small_packets, str(le_nano_file))
+    print(f"  Created: {le_nano_file} ({le_nano_file.stat().st_size} bytes)")
+
+    # 5. Legacy BE Nano
+    be_nano_file = output_dir / "format_be_nano.pcap"
+    write_be_nano(small_packets, str(be_nano_file))
+    print(f"  Created: {be_nano_file} ({be_nano_file.stat().st_size} bytes)")
+
+    # 6. PCAPNG
+    pcapng_file = output_dir / "format_pcapng.pcapng"
+    write_pcapng(small_packets, str(pcapng_file))
+    print(f"  Created: {pcapng_file} ({pcapng_file.stat().st_size} bytes)")
+
+    # Generate large file for chunk boundary testing
+    print(f"\nGenerating large file ({args.large_size}MB)...")
+    large_packets = generate_large_packets(args.large_size)
+
+    large_file = output_dir / "large_10mb.pcap"
+    write_le_micro(large_packets, str(large_file))
+    size_mb = large_file.stat().st_size / (1024 * 1024)
+    print(f"  Created: {large_file} ({size_mb:.2f} MB)")
+
+    print("\nDone! Generated files:")
+    for f in sorted(output_dir.glob("*")):
+        size = f.stat().st_size
+        if size > 1024 * 1024:
+            print(f"  {f.name}: {size / (1024*1024):.2f} MB")
+        else:
+            print(f"  {f.name}: {size} bytes")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add support for reading PCAP files directly from S3, GCS, and Azure cloud storage using the `object_store` crate.

### Features
- `CloudPacketSource` and `CloudPacketReader` for streaming cloud objects
- Chunked byte-range fetching (8MB default) for bounded memory usage
- Automatic compression detection (gzip, zstd, lz4) from file extension
- All PCAP formats supported (legacy LE/BE micro/nano, PCAPNG)
- CLI integration: `pcapsql s3://bucket/file.pcap -e 'SELECT ...'`
- `QueryEngine::with_cloud_source()` for programmatic access
- Runtime-safe async handling (works from both sync and async contexts)

### CLI Options
```
--endpoint    Custom S3-compatible endpoint (MinIO, LocalStack, R2)
--anonymous   Skip signature for public buckets  
--chunk-size  Byte-range request size (default 8MB)
```

### Example Usage
```bash
# Query from S3
pcapsql s3://my-bucket/capture.pcap.gz -e "SELECT COUNT(*) FROM frames"

# With custom endpoint (MinIO/LocalStack)
pcapsql s3://bucket/file.pcap --endpoint http://localhost:9000 --anonymous -e "SELECT * FROM dns"
```

## Test plan
- [x] Unit tests for CloudLocation parsing
- [x] Integration tests with LocalStack (17 tests)
- [x] Format tests: legacy LE/BE micro/nano, PCAPNG
- [x] Compression tests: gzip, zstd, lz4
- [x] Large file test (>8MB chunk boundary crossing)
- [x] Query engine integration tests