### PR TITLE
feat(udf): add protocol enumeration UDFs (Tier 1 & Tier 2)

### DIFF
--- a/pcapsql-core/src/protocol/gtp.rs
+++ b/pcapsql-core/src/protocol/gtp.rs
@@ -23,13 +23,49 @@ pub const GTP_C_PORT: u16 = 2123;
 /// Maximum extension headers to parse (safety limit).
 const MAX_EXTENSION_HEADERS: usize = 16;
 
-/// GTP message types.
-#[allow(dead_code)]
+/// GTP message types (GTPv1-C, GTPv1-U, GTPv2-C).
 pub mod message_type {
+    // Common messages
     pub const ECHO_REQUEST: u8 = 1;
     pub const ECHO_RESPONSE: u8 = 2;
+    pub const VERSION_NOT_SUPPORTED: u8 = 3;
+
+    // GTPv1-C messages (3GPP TS 29.060)
+    pub const CREATE_PDP_CONTEXT_REQUEST: u8 = 16;
+    pub const CREATE_PDP_CONTEXT_RESPONSE: u8 = 17;
+    pub const UPDATE_PDP_CONTEXT_REQUEST: u8 = 18;
+    pub const UPDATE_PDP_CONTEXT_RESPONSE: u8 = 19;
+    pub const DELETE_PDP_CONTEXT_REQUEST: u8 = 20;
+    pub const DELETE_PDP_CONTEXT_RESPONSE: u8 = 21;
     pub const ERROR_INDICATION: u8 = 26;
+    pub const PDU_NOTIFICATION_REQUEST: u8 = 27;
+    pub const PDU_NOTIFICATION_RESPONSE: u8 = 28;
     pub const SUPPORTED_EXTENSION_HEADERS_NOTIFICATION: u8 = 31;
+
+    // GTPv2-C messages (3GPP TS 29.274)
+    pub const CREATE_SESSION_REQUEST: u8 = 32;
+    pub const CREATE_SESSION_RESPONSE: u8 = 33;
+    pub const MODIFY_BEARER_REQUEST: u8 = 34;
+    pub const MODIFY_BEARER_RESPONSE: u8 = 35;
+    pub const DELETE_SESSION_REQUEST: u8 = 36;
+    pub const DELETE_SESSION_RESPONSE: u8 = 37;
+    pub const CHANGE_NOTIFICATION_REQUEST: u8 = 38;
+    pub const CHANGE_NOTIFICATION_RESPONSE: u8 = 39;
+    pub const MODIFY_BEARER_COMMAND: u8 = 64;
+    pub const MODIFY_BEARER_FAILURE_INDICATION: u8 = 65;
+    pub const DELETE_BEARER_COMMAND: u8 = 66;
+    pub const DELETE_BEARER_FAILURE_INDICATION: u8 = 67;
+    pub const BEARER_RESOURCE_COMMAND: u8 = 68;
+    pub const BEARER_RESOURCE_FAILURE_INDICATION: u8 = 69;
+    pub const DOWNLINK_DATA_NOTIFICATION_FAILURE_INDICATION: u8 = 70;
+    pub const CREATE_BEARER_REQUEST: u8 = 95;
+    pub const CREATE_BEARER_RESPONSE: u8 = 96;
+    pub const UPDATE_BEARER_REQUEST: u8 = 97;
+    pub const UPDATE_BEARER_RESPONSE: u8 = 98;
+    pub const DELETE_BEARER_REQUEST: u8 = 99;
+    pub const DELETE_BEARER_RESPONSE: u8 = 100;
+
+    // GTPv1-U messages (3GPP TS 29.281)
     pub const END_MARKER: u8 = 254;
     pub const G_PDU: u8 = 255;
 }

--- a/pcapsql-core/src/protocol/icmp.rs
+++ b/pcapsql-core/src/protocol/icmp.rs
@@ -15,10 +15,57 @@ pub mod icmp_type {
     pub const SOURCE_QUENCH: u8 = 4;
     pub const REDIRECT: u8 = 5;
     pub const ECHO_REQUEST: u8 = 8;
+    pub const ROUTER_ADVERTISEMENT: u8 = 9;
+    pub const ROUTER_SOLICITATION: u8 = 10;
     pub const TIME_EXCEEDED: u8 = 11;
     pub const PARAMETER_PROBLEM: u8 = 12;
     pub const TIMESTAMP_REQUEST: u8 = 13;
     pub const TIMESTAMP_REPLY: u8 = 14;
+    pub const INFO_REQUEST: u8 = 15;
+    pub const INFO_REPLY: u8 = 16;
+    pub const ADDRESS_MASK_REQUEST: u8 = 17;
+    pub const ADDRESS_MASK_REPLY: u8 = 18;
+}
+
+/// ICMP Destination Unreachable code constants (RFC 792, RFC 1122).
+pub mod dest_unreachable_code {
+    pub const NET_UNREACHABLE: u8 = 0;
+    pub const HOST_UNREACHABLE: u8 = 1;
+    pub const PROTOCOL_UNREACHABLE: u8 = 2;
+    pub const PORT_UNREACHABLE: u8 = 3;
+    pub const FRAGMENTATION_NEEDED: u8 = 4;
+    pub const SOURCE_ROUTE_FAILED: u8 = 5;
+    pub const DEST_NET_UNKNOWN: u8 = 6;
+    pub const DEST_HOST_UNKNOWN: u8 = 7;
+    pub const SOURCE_HOST_ISOLATED: u8 = 8;
+    pub const NET_ADMIN_PROHIBITED: u8 = 9;
+    pub const HOST_ADMIN_PROHIBITED: u8 = 10;
+    pub const NET_TOS_UNREACHABLE: u8 = 11;
+    pub const HOST_TOS_UNREACHABLE: u8 = 12;
+    pub const COMM_ADMIN_PROHIBITED: u8 = 13;
+    pub const HOST_PRECEDENCE_VIOLATION: u8 = 14;
+    pub const PRECEDENCE_CUTOFF: u8 = 15;
+}
+
+/// ICMP Redirect code constants.
+pub mod redirect_code {
+    pub const REDIRECT_NET: u8 = 0;
+    pub const REDIRECT_HOST: u8 = 1;
+    pub const REDIRECT_TOS_NET: u8 = 2;
+    pub const REDIRECT_TOS_HOST: u8 = 3;
+}
+
+/// ICMP Time Exceeded code constants.
+pub mod time_exceeded_code {
+    pub const TTL_EXCEEDED: u8 = 0;
+    pub const FRAGMENT_REASSEMBLY_EXCEEDED: u8 = 1;
+}
+
+/// ICMP Parameter Problem code constants.
+pub mod parameter_problem_code {
+    pub const POINTER_ERROR: u8 = 0;
+    pub const MISSING_REQUIRED_OPTION: u8 = 1;
+    pub const BAD_LENGTH: u8 = 2;
 }
 
 /// ICMP protocol parser.
@@ -69,8 +116,8 @@ impl Protocol for IcmpProtocol {
                 fields.push(("sequence", FieldValue::UInt16(sequence)));
             }
             icmp_type::DESTINATION_UNREACHABLE => {
-                // Next-hop MTU for "fragmentation needed" (code 4)
-                if icmp_code == 4 && data.len() >= 8 {
+                // Next-hop MTU for "fragmentation needed"
+                if icmp_code == dest_unreachable_code::FRAGMENTATION_NEEDED && data.len() >= 8 {
                     let mtu = u16::from_be_bytes([data[6], data[7]]);
                     fields.push(("next_hop_mtu", FieldValue::UInt16(mtu)));
                 }
@@ -94,10 +141,16 @@ impl Protocol for IcmpProtocol {
             icmp_type::SOURCE_QUENCH => "Source Quench",
             icmp_type::REDIRECT => "Redirect",
             icmp_type::ECHO_REQUEST => "Echo Request",
+            icmp_type::ROUTER_ADVERTISEMENT => "Router Advertisement",
+            icmp_type::ROUTER_SOLICITATION => "Router Solicitation",
             icmp_type::TIME_EXCEEDED => "Time Exceeded",
             icmp_type::PARAMETER_PROBLEM => "Parameter Problem",
             icmp_type::TIMESTAMP_REQUEST => "Timestamp Request",
             icmp_type::TIMESTAMP_REPLY => "Timestamp Reply",
+            icmp_type::INFO_REQUEST => "Information Request",
+            icmp_type::INFO_REPLY => "Information Reply",
+            icmp_type::ADDRESS_MASK_REQUEST => "Address Mask Request",
+            icmp_type::ADDRESS_MASK_REPLY => "Address Mask Reply",
             _ => "Unknown",
         };
         fields.push(("type_name", FieldValue::Str(type_name)));

--- a/pcapsql-core/src/protocol/icmpv6.rs
+++ b/pcapsql-core/src/protocol/icmpv6.rs
@@ -37,6 +37,32 @@ pub mod icmpv6_type {
     pub const REDIRECT: u8 = 137;
 }
 
+/// ICMPv6 Destination Unreachable code constants (RFC 4443).
+pub mod dest_unreachable_code {
+    pub const NO_ROUTE: u8 = 0;
+    pub const ADMIN_PROHIBITED: u8 = 1;
+    pub const BEYOND_SCOPE: u8 = 2;
+    pub const ADDRESS_UNREACHABLE: u8 = 3;
+    pub const PORT_UNREACHABLE: u8 = 4;
+    pub const FAILED_POLICY: u8 = 5;
+    pub const REJECT_ROUTE: u8 = 6;
+    pub const SOURCE_ROUTING_ERROR: u8 = 7;
+}
+
+/// ICMPv6 Time Exceeded code constants.
+pub mod time_exceeded_code {
+    pub const HOP_LIMIT_EXCEEDED: u8 = 0;
+    pub const FRAGMENT_REASSEMBLY_EXCEEDED: u8 = 1;
+}
+
+/// ICMPv6 Parameter Problem code constants.
+pub mod parameter_problem_code {
+    pub const ERRONEOUS_HEADER: u8 = 0;
+    pub const UNRECOGNIZED_NEXT_HEADER: u8 = 1;
+    pub const UNRECOGNIZED_OPTION: u8 = 2;
+    pub const INCOMPLETE_HEADER: u8 = 3;
+}
+
 /// NDP option type constants.
 pub mod ndp_option {
     pub const SOURCE_LINK_LAYER_ADDR: u8 = 1;

--- a/pcapsql-core/src/protocol/mod.rs
+++ b/pcapsql-core/src/protocol/mod.rs
@@ -109,10 +109,25 @@ pub use vlan::VlanProtocol;
 pub use vxlan::VxlanProtocol;
 
 // Re-export protocol constants for use in UDFs and other crates
+pub use bgp::{message_type as bgp_message_type, origin_type as bgp_origin_type};
 pub use dns::{rcode, record_type};
 pub use ethernet::ethertype;
+pub use gtp::message_type as gtp_message_type;
+pub use icmp::{
+    dest_unreachable_code as icmp_dest_unreachable_code, icmp_type,
+    parameter_problem_code as icmp_parameter_problem_code, redirect_code as icmp_redirect_code,
+    time_exceeded_code as icmp_time_exceeded_code,
+};
+pub use icmpv6::{
+    dest_unreachable_code as icmpv6_dest_unreachable_code, icmpv6_type,
+    parameter_problem_code as icmpv6_parameter_problem_code,
+    time_exceeded_code as icmpv6_time_exceeded_code,
+};
 pub use ipv6::next_header;
 pub use netlink::family as netlink_family;
+pub use ntp::{mode as ntp_mode, stratum as ntp_stratum};
+pub use ospf::{lsa_type as ospf_lsa_type, packet_type as ospf_packet_type};
+pub use tls::{record_type as tls_record_type, version as tls_version};
 
 /// Create a registry with all built-in protocol parsers.
 pub fn default_registry() -> ProtocolRegistry {

--- a/pcapsql-core/src/protocol/ospf.rs
+++ b/pcapsql-core/src/protocol/ospf.rs
@@ -24,7 +24,7 @@ pub mod packet_type {
     pub const LINK_STATE_ACK: u8 = 5;
 }
 
-/// OSPF LSA types (RFC 2328).
+/// OSPF LSA types (RFC 2328, RFC 5250).
 pub mod lsa_type {
     /// Router-LSA: Describes router's links within an area.
     pub const ROUTER: u8 = 1;
@@ -36,6 +36,18 @@ pub mod lsa_type {
     pub const SUMMARY_ASBR: u8 = 4;
     /// AS-External-LSA: Describes route to external network.
     pub const AS_EXTERNAL: u8 = 5;
+    /// Group-Membership-LSA (RFC 1584): MOSPF group membership.
+    pub const GROUP_MEMBERSHIP: u8 = 6;
+    /// NSSA-External-LSA (RFC 3101): Not-so-stubby area external routes.
+    pub const NSSA_EXTERNAL: u8 = 7;
+    /// External-Attributes-LSA (deprecated).
+    pub const EXTERNAL_ATTRIBUTES: u8 = 8;
+    /// Opaque-Link-LSA (RFC 5250): Link-local scope opaque LSA.
+    pub const OPAQUE_LINK: u8 = 9;
+    /// Opaque-Area-LSA (RFC 5250): Area scope opaque LSA.
+    pub const OPAQUE_AREA: u8 = 10;
+    /// Opaque-AS-LSA (RFC 5250): AS scope opaque LSA.
+    pub const OPAQUE_AS: u8 = 11;
 }
 
 /// Get the name of an LSA type.
@@ -46,6 +58,12 @@ fn lsa_type_name(ls_type: u8) -> &'static str {
         lsa_type::SUMMARY_NETWORK => "Summary-LSA-Network",
         lsa_type::SUMMARY_ASBR => "Summary-LSA-ASBR",
         lsa_type::AS_EXTERNAL => "AS-External-LSA",
+        lsa_type::GROUP_MEMBERSHIP => "Group-Membership-LSA",
+        lsa_type::NSSA_EXTERNAL => "NSSA-External-LSA",
+        lsa_type::EXTERNAL_ATTRIBUTES => "External-Attributes-LSA",
+        lsa_type::OPAQUE_LINK => "Opaque-Link-LSA",
+        lsa_type::OPAQUE_AREA => "Opaque-Area-LSA",
+        lsa_type::OPAQUE_AS => "Opaque-AS-LSA",
         _ => "Unknown",
     }
 }

--- a/pcapsql-core/src/protocol/tls.rs
+++ b/pcapsql-core/src/protocol/tls.rs
@@ -31,6 +31,74 @@ use crate::schema::{DataKind, FieldDescriptor};
 #[allow(dead_code)]
 pub const TLS_PORT: u16 = 443;
 
+/// TLS version constants.
+pub mod version {
+    /// SSL 2.0 (obsolete, insecure).
+    pub const SSL_2_0: u16 = 0x0200;
+    /// SSL 3.0 (obsolete, insecure).
+    pub const SSL_3_0: u16 = 0x0300;
+    /// TLS 1.0 (RFC 2246).
+    pub const TLS_1_0: u16 = 0x0301;
+    /// TLS 1.1 (RFC 4346).
+    pub const TLS_1_1: u16 = 0x0302;
+    /// TLS 1.2 (RFC 5246).
+    pub const TLS_1_2: u16 = 0x0303;
+    /// TLS 1.3 (RFC 8446).
+    pub const TLS_1_3: u16 = 0x0304;
+}
+
+/// TLS record type constants.
+pub mod record_type {
+    /// Change Cipher Spec message.
+    pub const CHANGE_CIPHER_SPEC: u8 = 20;
+    /// Alert message.
+    pub const ALERT: u8 = 21;
+    /// Handshake message.
+    pub const HANDSHAKE: u8 = 22;
+    /// Application data (encrypted).
+    pub const APPLICATION_DATA: u8 = 23;
+    /// Heartbeat (RFC 6520).
+    pub const HEARTBEAT: u8 = 24;
+}
+
+/// TLS alert description constants.
+pub mod alert {
+    pub const CLOSE_NOTIFY: u8 = 0;
+    pub const UNEXPECTED_MESSAGE: u8 = 10;
+    pub const BAD_RECORD_MAC: u8 = 20;
+    pub const DECRYPTION_FAILED: u8 = 21;
+    pub const RECORD_OVERFLOW: u8 = 22;
+    pub const DECOMPRESSION_FAILURE: u8 = 30;
+    pub const HANDSHAKE_FAILURE: u8 = 40;
+    pub const NO_CERTIFICATE: u8 = 41;
+    pub const BAD_CERTIFICATE: u8 = 42;
+    pub const UNSUPPORTED_CERTIFICATE: u8 = 43;
+    pub const CERTIFICATE_REVOKED: u8 = 44;
+    pub const CERTIFICATE_EXPIRED: u8 = 45;
+    pub const CERTIFICATE_UNKNOWN: u8 = 46;
+    pub const ILLEGAL_PARAMETER: u8 = 47;
+    pub const UNKNOWN_CA: u8 = 48;
+    pub const ACCESS_DENIED: u8 = 49;
+    pub const DECODE_ERROR: u8 = 50;
+    pub const DECRYPT_ERROR: u8 = 51;
+    pub const EXPORT_RESTRICTION: u8 = 60;
+    pub const PROTOCOL_VERSION: u8 = 70;
+    pub const INSUFFICIENT_SECURITY: u8 = 71;
+    pub const INTERNAL_ERROR: u8 = 80;
+    pub const INAPPROPRIATE_FALLBACK: u8 = 86;
+    pub const USER_CANCELED: u8 = 90;
+    pub const NO_RENEGOTIATION: u8 = 100;
+    pub const MISSING_EXTENSION: u8 = 109;
+    pub const UNSUPPORTED_EXTENSION: u8 = 110;
+    pub const CERTIFICATE_UNOBTAINABLE: u8 = 111;
+    pub const UNRECOGNIZED_NAME: u8 = 112;
+    pub const BAD_CERTIFICATE_STATUS_RESPONSE: u8 = 113;
+    pub const BAD_CERTIFICATE_HASH_VALUE: u8 = 114;
+    pub const UNKNOWN_PSK_IDENTITY: u8 = 115;
+    pub const CERTIFICATE_REQUIRED: u8 = 116;
+    pub const NO_APPLICATION_PROTOCOL: u8 = 120;
+}
+
 /// Common TLS ports for priority matching.
 const TLS_PORTS: &[u16] = &[
     443,   // HTTPS
@@ -631,13 +699,14 @@ fn is_grease_value(val: u16) -> bool {
 }
 
 /// Format TLS version from TlsVersion.
-fn format_tls_version(version: TlsVersion) -> String {
-    match version.0 {
-        0x0300 => "SSL 3.0".to_string(),
-        0x0301 => "TLS 1.0".to_string(),
-        0x0302 => "TLS 1.1".to_string(),
-        0x0303 => "TLS 1.2".to_string(),
-        0x0304 => "TLS 1.3".to_string(),
+fn format_tls_version(ver: TlsVersion) -> String {
+    match ver.0 {
+        version::SSL_2_0 => "SSL 2.0".to_string(),
+        version::SSL_3_0 => "SSL 3.0".to_string(),
+        version::TLS_1_0 => "TLS 1.0".to_string(),
+        version::TLS_1_1 => "TLS 1.1".to_string(),
+        version::TLS_1_2 => "TLS 1.2".to_string(),
+        version::TLS_1_3 => "TLS 1.3".to_string(),
         v if is_grease_value(v) => "GREASE".to_string(),
         v => format!("Unknown (0x{v:04x})"),
     }
@@ -744,40 +813,40 @@ fn format_ec_point_format(fmt: u8) -> String {
 /// Format TLS alert description.
 fn format_alert_description(code: u8) -> &'static str {
     match code {
-        0 => "close_notify",
-        10 => "unexpected_message",
-        20 => "bad_record_mac",
-        21 => "decryption_failed",
-        22 => "record_overflow",
-        30 => "decompression_failure",
-        40 => "handshake_failure",
-        41 => "no_certificate",
-        42 => "bad_certificate",
-        43 => "unsupported_certificate",
-        44 => "certificate_revoked",
-        45 => "certificate_expired",
-        46 => "certificate_unknown",
-        47 => "illegal_parameter",
-        48 => "unknown_ca",
-        49 => "access_denied",
-        50 => "decode_error",
-        51 => "decrypt_error",
-        60 => "export_restriction",
-        70 => "protocol_version",
-        71 => "insufficient_security",
-        80 => "internal_error",
-        86 => "inappropriate_fallback",
-        90 => "user_canceled",
-        100 => "no_renegotiation",
-        109 => "missing_extension",
-        110 => "unsupported_extension",
-        111 => "certificate_unobtainable",
-        112 => "unrecognized_name",
-        113 => "bad_certificate_status_response",
-        114 => "bad_certificate_hash_value",
-        115 => "unknown_psk_identity",
-        116 => "certificate_required",
-        120 => "no_application_protocol",
+        alert::CLOSE_NOTIFY => "close_notify",
+        alert::UNEXPECTED_MESSAGE => "unexpected_message",
+        alert::BAD_RECORD_MAC => "bad_record_mac",
+        alert::DECRYPTION_FAILED => "decryption_failed",
+        alert::RECORD_OVERFLOW => "record_overflow",
+        alert::DECOMPRESSION_FAILURE => "decompression_failure",
+        alert::HANDSHAKE_FAILURE => "handshake_failure",
+        alert::NO_CERTIFICATE => "no_certificate",
+        alert::BAD_CERTIFICATE => "bad_certificate",
+        alert::UNSUPPORTED_CERTIFICATE => "unsupported_certificate",
+        alert::CERTIFICATE_REVOKED => "certificate_revoked",
+        alert::CERTIFICATE_EXPIRED => "certificate_expired",
+        alert::CERTIFICATE_UNKNOWN => "certificate_unknown",
+        alert::ILLEGAL_PARAMETER => "illegal_parameter",
+        alert::UNKNOWN_CA => "unknown_ca",
+        alert::ACCESS_DENIED => "access_denied",
+        alert::DECODE_ERROR => "decode_error",
+        alert::DECRYPT_ERROR => "decrypt_error",
+        alert::EXPORT_RESTRICTION => "export_restriction",
+        alert::PROTOCOL_VERSION => "protocol_version",
+        alert::INSUFFICIENT_SECURITY => "insufficient_security",
+        alert::INTERNAL_ERROR => "internal_error",
+        alert::INAPPROPRIATE_FALLBACK => "inappropriate_fallback",
+        alert::USER_CANCELED => "user_canceled",
+        alert::NO_RENEGOTIATION => "no_renegotiation",
+        alert::MISSING_EXTENSION => "missing_extension",
+        alert::UNSUPPORTED_EXTENSION => "unsupported_extension",
+        alert::CERTIFICATE_UNOBTAINABLE => "certificate_unobtainable",
+        alert::UNRECOGNIZED_NAME => "unrecognized_name",
+        alert::BAD_CERTIFICATE_STATUS_RESPONSE => "bad_certificate_status_response",
+        alert::BAD_CERTIFICATE_HASH_VALUE => "bad_certificate_hash_value",
+        alert::UNKNOWN_PSK_IDENTITY => "unknown_psk_identity",
+        alert::CERTIFICATE_REQUIRED => "certificate_required",
+        alert::NO_APPLICATION_PROTOCOL => "no_application_protocol",
         _ => "unknown",
     }
 }

--- a/pcapsql-datafusion/src/query/udf/bgp.rs
+++ b/pcapsql-datafusion/src/query/udf/bgp.rs
@@ -1,0 +1,186 @@
+//! BGP protocol UDFs.
+//!
+//! Provides functions for converting BGP message types and path attributes to human-readable names.
+//! Uses protocol constants from pcapsql-core for consistency.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, StringArray, UInt8Array};
+use arrow::datatypes::DataType;
+use datafusion::common::Result as DFResult;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use pcapsql_core::protocol::{bgp_message_type as message_type, bgp_origin_type as origin_type};
+
+/// Create the `bgp_message_type_name()` UDF.
+///
+/// # Example
+/// ```sql
+/// SELECT bgp_message_type_name(message_type) FROM bgp;
+/// -- Returns: "OPEN", "UPDATE", "NOTIFICATION", "KEEPALIVE", "ROUTE-REFRESH"
+/// ```
+pub fn create_bgp_message_type_name_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(BgpMessageTypeNameUdf::new())
+}
+
+/// Create the `bgp_origin_name()` UDF.
+///
+/// # Example
+/// ```sql
+/// SELECT bgp_origin_name(origin) FROM bgp WHERE origin IS NOT NULL;
+/// -- Returns: "IGP", "EGP", "INCOMPLETE"
+/// ```
+pub fn create_bgp_origin_name_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(BgpOriginNameUdf::new())
+}
+
+// ============================================================================
+// bgp_message_type_name() UDF Implementation
+// ============================================================================
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct BgpMessageTypeNameUdf {
+    signature: Signature,
+}
+
+impl BgpMessageTypeNameUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::UInt8], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for BgpMessageTypeNameUdf {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "bgp_message_type_name"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        let values = args[0]
+            .as_any()
+            .downcast_ref::<UInt8Array>()
+            .expect("bgp_message_type_name: expected uint8 array");
+
+        let result: StringArray = values
+            .iter()
+            .map(|opt| opt.map(bgp_message_type_to_name))
+            .collect();
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    }
+}
+
+fn bgp_message_type_to_name(msg_type: u8) -> String {
+    match msg_type {
+        message_type::OPEN => "OPEN".to_string(),
+        message_type::UPDATE => "UPDATE".to_string(),
+        message_type::NOTIFICATION => "NOTIFICATION".to_string(),
+        message_type::KEEPALIVE => "KEEPALIVE".to_string(),
+        message_type::ROUTE_REFRESH => "ROUTE-REFRESH".to_string(),
+        _ => format!("Unknown ({msg_type})"),
+    }
+}
+
+// ============================================================================
+// bgp_origin_name() UDF Implementation
+// ============================================================================
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct BgpOriginNameUdf {
+    signature: Signature,
+}
+
+impl BgpOriginNameUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::UInt8], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for BgpOriginNameUdf {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "bgp_origin_name"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        let values = args[0]
+            .as_any()
+            .downcast_ref::<UInt8Array>()
+            .expect("bgp_origin_name: expected uint8 array");
+
+        let result: StringArray = values
+            .iter()
+            .map(|opt| opt.map(bgp_origin_to_name))
+            .collect();
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    }
+}
+
+fn bgp_origin_to_name(origin: u8) -> String {
+    match origin {
+        origin_type::IGP => "IGP".to_string(),
+        origin_type::EGP => "EGP".to_string(),
+        origin_type::INCOMPLETE => "INCOMPLETE".to_string(),
+        _ => format!("Unknown ({origin})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bgp_message_type_name() {
+        assert_eq!(bgp_message_type_to_name(message_type::OPEN), "OPEN");
+        assert_eq!(bgp_message_type_to_name(message_type::UPDATE), "UPDATE");
+        assert_eq!(
+            bgp_message_type_to_name(message_type::NOTIFICATION),
+            "NOTIFICATION"
+        );
+        assert_eq!(
+            bgp_message_type_to_name(message_type::KEEPALIVE),
+            "KEEPALIVE"
+        );
+        assert_eq!(
+            bgp_message_type_to_name(message_type::ROUTE_REFRESH),
+            "ROUTE-REFRESH"
+        );
+        assert_eq!(bgp_message_type_to_name(99), "Unknown (99)");
+    }
+
+    #[test]
+    fn test_bgp_origin_name() {
+        assert_eq!(bgp_origin_to_name(origin_type::IGP), "IGP");
+        assert_eq!(bgp_origin_to_name(origin_type::EGP), "EGP");
+        assert_eq!(bgp_origin_to_name(origin_type::INCOMPLETE), "INCOMPLETE");
+        assert_eq!(bgp_origin_to_name(3), "Unknown (3)");
+    }
+}

--- a/pcapsql-datafusion/src/query/udf/gtp.rs
+++ b/pcapsql-datafusion/src/query/udf/gtp.rs
@@ -1,0 +1,161 @@
+//! GTP protocol UDFs.
+//!
+//! Provides functions for converting GTP message types to human-readable names.
+//! Uses protocol constants from pcapsql-core for consistency.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, StringArray, UInt8Array};
+use arrow::datatypes::DataType;
+use datafusion::common::Result as DFResult;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use pcapsql_core::protocol::gtp_message_type as message_type;
+
+/// Create the `gtp_message_type_name()` UDF.
+///
+/// # Example
+/// ```sql
+/// SELECT gtp_message_type_name(message_type) FROM gtp;
+/// -- Returns: "Echo Request", "Echo Response", "G-PDU", etc.
+/// ```
+pub fn create_gtp_message_type_name_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(GtpMessageTypeNameUdf::new())
+}
+
+// ============================================================================
+// gtp_message_type_name() UDF Implementation
+// ============================================================================
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct GtpMessageTypeNameUdf {
+    signature: Signature,
+}
+
+impl GtpMessageTypeNameUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::UInt8], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for GtpMessageTypeNameUdf {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "gtp_message_type_name"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        let values = args[0]
+            .as_any()
+            .downcast_ref::<UInt8Array>()
+            .expect("gtp_message_type_name: expected uint8 array");
+
+        let result: StringArray = values
+            .iter()
+            .map(|opt| opt.map(gtp_message_type_to_name))
+            .collect();
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    }
+}
+
+fn gtp_message_type_to_name(msg_type: u8) -> String {
+    match msg_type {
+        // Common messages
+        message_type::ECHO_REQUEST => "Echo Request".to_string(),
+        message_type::ECHO_RESPONSE => "Echo Response".to_string(),
+        message_type::VERSION_NOT_SUPPORTED => "Version Not Supported".to_string(),
+        // GTPv1-C messages
+        message_type::CREATE_PDP_CONTEXT_REQUEST => "Create PDP Context Request".to_string(),
+        message_type::CREATE_PDP_CONTEXT_RESPONSE => "Create PDP Context Response".to_string(),
+        message_type::UPDATE_PDP_CONTEXT_REQUEST => "Update PDP Context Request".to_string(),
+        message_type::UPDATE_PDP_CONTEXT_RESPONSE => "Update PDP Context Response".to_string(),
+        message_type::DELETE_PDP_CONTEXT_REQUEST => "Delete PDP Context Request".to_string(),
+        message_type::DELETE_PDP_CONTEXT_RESPONSE => "Delete PDP Context Response".to_string(),
+        message_type::ERROR_INDICATION => "Error Indication".to_string(),
+        message_type::PDU_NOTIFICATION_REQUEST => "PDU Notification Request".to_string(),
+        message_type::PDU_NOTIFICATION_RESPONSE => "PDU Notification Response".to_string(),
+        message_type::SUPPORTED_EXTENSION_HEADERS_NOTIFICATION => {
+            "Supported Extension Headers Notification".to_string()
+        }
+        // GTPv2-C messages
+        message_type::CREATE_SESSION_REQUEST => "Create Session Request".to_string(),
+        message_type::CREATE_SESSION_RESPONSE => "Create Session Response".to_string(),
+        message_type::MODIFY_BEARER_REQUEST => "Modify Bearer Request".to_string(),
+        message_type::MODIFY_BEARER_RESPONSE => "Modify Bearer Response".to_string(),
+        message_type::DELETE_SESSION_REQUEST => "Delete Session Request".to_string(),
+        message_type::DELETE_SESSION_RESPONSE => "Delete Session Response".to_string(),
+        message_type::CHANGE_NOTIFICATION_REQUEST => "Change Notification Request".to_string(),
+        message_type::CHANGE_NOTIFICATION_RESPONSE => "Change Notification Response".to_string(),
+        message_type::MODIFY_BEARER_COMMAND => "Modify Bearer Command".to_string(),
+        message_type::MODIFY_BEARER_FAILURE_INDICATION => {
+            "Modify Bearer Failure Indication".to_string()
+        }
+        message_type::DELETE_BEARER_COMMAND => "Delete Bearer Command".to_string(),
+        message_type::DELETE_BEARER_FAILURE_INDICATION => {
+            "Delete Bearer Failure Indication".to_string()
+        }
+        message_type::BEARER_RESOURCE_COMMAND => "Bearer Resource Command".to_string(),
+        message_type::BEARER_RESOURCE_FAILURE_INDICATION => {
+            "Bearer Resource Failure Indication".to_string()
+        }
+        message_type::DOWNLINK_DATA_NOTIFICATION_FAILURE_INDICATION => {
+            "Downlink Data Notification Failure Indication".to_string()
+        }
+        message_type::CREATE_BEARER_REQUEST => "Create Bearer Request".to_string(),
+        message_type::CREATE_BEARER_RESPONSE => "Create Bearer Response".to_string(),
+        message_type::UPDATE_BEARER_REQUEST => "Update Bearer Request".to_string(),
+        message_type::UPDATE_BEARER_RESPONSE => "Update Bearer Response".to_string(),
+        message_type::DELETE_BEARER_REQUEST => "Delete Bearer Request".to_string(),
+        message_type::DELETE_BEARER_RESPONSE => "Delete Bearer Response".to_string(),
+        // GTPv1-U messages
+        message_type::END_MARKER => "End Marker".to_string(),
+        message_type::G_PDU => "G-PDU".to_string(),
+        _ => format!("Unknown ({msg_type})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gtp_message_type_name() {
+        assert_eq!(
+            gtp_message_type_to_name(message_type::ECHO_REQUEST),
+            "Echo Request"
+        );
+        assert_eq!(
+            gtp_message_type_to_name(message_type::ECHO_RESPONSE),
+            "Echo Response"
+        );
+        assert_eq!(gtp_message_type_to_name(message_type::G_PDU), "G-PDU");
+        assert_eq!(
+            gtp_message_type_to_name(message_type::END_MARKER),
+            "End Marker"
+        );
+        assert_eq!(
+            gtp_message_type_to_name(message_type::CREATE_SESSION_REQUEST),
+            "Create Session Request"
+        );
+        assert_eq!(
+            gtp_message_type_to_name(message_type::CREATE_PDP_CONTEXT_REQUEST),
+            "Create PDP Context Request"
+        );
+        assert_eq!(gtp_message_type_to_name(200), "Unknown (200)");
+    }
+}

--- a/pcapsql-datafusion/src/query/udf/info.rs
+++ b/pcapsql-datafusion/src/query/udf/info.rs
@@ -176,6 +176,22 @@ pub fn all_udfs() -> Vec<UdfInfo> {
             category: UdfCategory::Protocol,
         },
         UdfInfo {
+            name: "icmp_code_name",
+            description: "Convert ICMP type+code to detailed name",
+            signature: "icmp_code_name(uint8, uint8)",
+            return_type: "String",
+            example: "icmp_code_name(type, code) -> 'Port Unreachable'",
+            category: UdfCategory::Protocol,
+        },
+        UdfInfo {
+            name: "icmpv6_code_name",
+            description: "Convert ICMPv6 type+code to detailed name",
+            signature: "icmpv6_code_name(uint8, uint8)",
+            return_type: "String",
+            example: "icmpv6_code_name(type, code) -> 'No Route to Destination'",
+            category: UdfCategory::Protocol,
+        },
+        UdfInfo {
             name: "ip_proto_name",
             description: "Convert IP protocol number to name",
             signature: "ip_proto_name(uint8)",

--- a/pcapsql-datafusion/src/query/udf/mod.rs
+++ b/pcapsql-datafusion/src/query/udf/mod.rs
@@ -40,6 +40,8 @@
 //!
 //! - `icmp_type_name(type)` - Convert ICMP type to name (e.g., "Echo Request")
 //! - `icmpv6_type_name(type)` - Convert ICMPv6 type to name
+//! - `icmp_code_name(type, code)` - Convert ICMP type+code to detailed name (e.g., "Port Unreachable")
+//! - `icmpv6_code_name(type, code)` - Convert ICMPv6 type+code to detailed name
 //!
 //! ### Protocol Numbers
 //!
@@ -74,8 +76,10 @@
 //! SELECT ip_proto_name(protocol) AS proto, COUNT(*) FROM ipv4 GROUP BY protocol;
 //! ```
 
+mod bgp;
 mod datetime;
 mod dns;
+mod gtp;
 mod hex;
 mod histogram;
 mod icmp;
@@ -83,9 +87,12 @@ pub mod info;
 mod ipv4;
 mod ipv6;
 mod mac;
+mod ntp_proto;
+mod ospf;
 mod protocol;
 mod tcp;
 mod time;
+mod tls_proto;
 
 // Re-export address UDFs
 pub use ipv4::{create_ip4_to_string_udf, create_ip4_udf, create_ip_in_cidr_udf};
@@ -93,10 +100,18 @@ pub use ipv6::{create_ip6_in_cidr_udf, create_ip6_to_string_udf, create_ip6_udf}
 pub use mac::{create_mac_to_string_udf, create_mac_udf};
 
 // Re-export protocol UDFs
+pub use bgp::{create_bgp_message_type_name_udf, create_bgp_origin_name_udf};
 pub use dns::{create_dns_class_name_udf, create_dns_rcode_name_udf, create_dns_type_name_udf};
-pub use icmp::{create_icmp_type_name_udf, create_icmpv6_type_name_udf};
+pub use gtp::create_gtp_message_type_name_udf;
+pub use icmp::{
+    create_icmp_code_name_udf, create_icmp_type_name_udf, create_icmpv6_code_name_udf,
+    create_icmpv6_type_name_udf,
+};
+pub use ntp_proto::{create_ntp_mode_name_udf, create_ntp_stratum_name_udf};
+pub use ospf::{create_ospf_lsa_type_name_udf, create_ospf_packet_type_name_udf};
 pub use protocol::{create_ethertype_name_udf, create_ip_proto_name_udf};
 pub use tcp::{create_has_tcp_flag_udf, create_tcp_flags_str_udf};
+pub use tls_proto::{create_tls_record_type_name_udf, create_tls_version_name_udf};
 
 // Re-export utility UDFs
 pub use hex::{create_hex_udf, create_unhex_udf};
@@ -155,10 +170,31 @@ pub fn register_protocol_udfs(ctx: &SessionContext) -> Result<(), Error> {
     // ICMP
     ctx.register_udf(create_icmp_type_name_udf());
     ctx.register_udf(create_icmpv6_type_name_udf());
+    ctx.register_udf(create_icmp_code_name_udf());
+    ctx.register_udf(create_icmpv6_code_name_udf());
 
     // Protocol numbers
     ctx.register_udf(create_ip_proto_name_udf());
     ctx.register_udf(create_ethertype_name_udf());
+
+    // BGP
+    ctx.register_udf(create_bgp_message_type_name_udf());
+    ctx.register_udf(create_bgp_origin_name_udf());
+
+    // OSPF
+    ctx.register_udf(create_ospf_packet_type_name_udf());
+    ctx.register_udf(create_ospf_lsa_type_name_udf());
+
+    // GTP
+    ctx.register_udf(create_gtp_message_type_name_udf());
+
+    // NTP
+    ctx.register_udf(create_ntp_mode_name_udf());
+    ctx.register_udf(create_ntp_stratum_name_udf());
+
+    // TLS
+    ctx.register_udf(create_tls_version_name_udf());
+    ctx.register_udf(create_tls_record_type_name_udf());
 
     Ok(())
 }

--- a/pcapsql-datafusion/src/query/udf/ntp_proto.rs
+++ b/pcapsql-datafusion/src/query/udf/ntp_proto.rs
@@ -1,0 +1,189 @@
+//! NTP protocol UDFs.
+//!
+//! Provides functions for converting NTP mode and stratum values to human-readable names.
+//! Uses protocol constants from pcapsql-core for consistency.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, StringArray, UInt8Array};
+use arrow::datatypes::DataType;
+use datafusion::common::Result as DFResult;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use pcapsql_core::protocol::{ntp_mode as mode, ntp_stratum as stratum};
+
+/// Create the `ntp_mode_name()` UDF.
+///
+/// # Example
+/// ```sql
+/// SELECT ntp_mode_name(mode) FROM ntp;
+/// -- Returns: "Client", "Server", "Broadcast", etc.
+/// ```
+pub fn create_ntp_mode_name_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(NtpModeNameUdf::new())
+}
+
+/// Create the `ntp_stratum_name()` UDF.
+///
+/// # Example
+/// ```sql
+/// SELECT ntp_stratum_name(stratum) FROM ntp;
+/// -- Returns: "Unspecified", "Primary Reference", "Secondary", etc.
+/// ```
+pub fn create_ntp_stratum_name_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(NtpStratumNameUdf::new())
+}
+
+// ============================================================================
+// ntp_mode_name() UDF Implementation
+// ============================================================================
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct NtpModeNameUdf {
+    signature: Signature,
+}
+
+impl NtpModeNameUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::UInt8], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for NtpModeNameUdf {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "ntp_mode_name"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        let values = args[0]
+            .as_any()
+            .downcast_ref::<UInt8Array>()
+            .expect("ntp_mode_name: expected uint8 array");
+
+        let result: StringArray = values.iter().map(|opt| opt.map(ntp_mode_to_name)).collect();
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    }
+}
+
+fn ntp_mode_to_name(m: u8) -> String {
+    match m {
+        mode::RESERVED => "Reserved".to_string(),
+        mode::SYMMETRIC_ACTIVE => "Symmetric Active".to_string(),
+        mode::SYMMETRIC_PASSIVE => "Symmetric Passive".to_string(),
+        mode::CLIENT => "Client".to_string(),
+        mode::SERVER => "Server".to_string(),
+        mode::BROADCAST => "Broadcast".to_string(),
+        mode::CONTROL => "NTP Control".to_string(),
+        mode::PRIVATE => "Private".to_string(),
+        _ => format!("Unknown ({m})"),
+    }
+}
+
+// ============================================================================
+// ntp_stratum_name() UDF Implementation
+// ============================================================================
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct NtpStratumNameUdf {
+    signature: Signature,
+}
+
+impl NtpStratumNameUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::UInt8], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for NtpStratumNameUdf {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "ntp_stratum_name"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        let values = args[0]
+            .as_any()
+            .downcast_ref::<UInt8Array>()
+            .expect("ntp_stratum_name: expected uint8 array");
+
+        let result: StringArray = values
+            .iter()
+            .map(|opt| opt.map(ntp_stratum_to_name))
+            .collect();
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    }
+}
+
+fn ntp_stratum_to_name(s: u8) -> String {
+    match s {
+        stratum::UNSPECIFIED => "Unspecified".to_string(),
+        stratum::PRIMARY => "Primary Reference".to_string(),
+        2..=15 => format!("Secondary (stratum {s})"),
+        stratum::UNSYNCHRONIZED => "Unsynchronized".to_string(),
+        _ => format!("Reserved ({s})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ntp_mode_name() {
+        assert_eq!(ntp_mode_to_name(mode::RESERVED), "Reserved");
+        assert_eq!(ntp_mode_to_name(mode::SYMMETRIC_ACTIVE), "Symmetric Active");
+        assert_eq!(
+            ntp_mode_to_name(mode::SYMMETRIC_PASSIVE),
+            "Symmetric Passive"
+        );
+        assert_eq!(ntp_mode_to_name(mode::CLIENT), "Client");
+        assert_eq!(ntp_mode_to_name(mode::SERVER), "Server");
+        assert_eq!(ntp_mode_to_name(mode::BROADCAST), "Broadcast");
+        assert_eq!(ntp_mode_to_name(mode::CONTROL), "NTP Control");
+        assert_eq!(ntp_mode_to_name(mode::PRIVATE), "Private");
+        assert_eq!(ntp_mode_to_name(8), "Unknown (8)");
+    }
+
+    #[test]
+    fn test_ntp_stratum_name() {
+        assert_eq!(ntp_stratum_to_name(stratum::UNSPECIFIED), "Unspecified");
+        assert_eq!(ntp_stratum_to_name(stratum::PRIMARY), "Primary Reference");
+        assert_eq!(ntp_stratum_to_name(2), "Secondary (stratum 2)");
+        assert_eq!(ntp_stratum_to_name(15), "Secondary (stratum 15)");
+        assert_eq!(
+            ntp_stratum_to_name(stratum::UNSYNCHRONIZED),
+            "Unsynchronized"
+        );
+        assert_eq!(ntp_stratum_to_name(17), "Reserved (17)");
+    }
+}

--- a/pcapsql-datafusion/src/query/udf/ospf.rs
+++ b/pcapsql-datafusion/src/query/udf/ospf.rs
@@ -1,0 +1,204 @@
+//! OSPF protocol UDFs.
+//!
+//! Provides functions for converting OSPF packet types and LSA types to human-readable names.
+//! Uses protocol constants from pcapsql-core for consistency.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, StringArray, UInt8Array};
+use arrow::datatypes::DataType;
+use datafusion::common::Result as DFResult;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use pcapsql_core::protocol::{ospf_lsa_type as lsa_type, ospf_packet_type as packet_type};
+
+/// Create the `ospf_packet_type_name()` UDF.
+///
+/// # Example
+/// ```sql
+/// SELECT ospf_packet_type_name(message_type) FROM ospf;
+/// -- Returns: "Hello", "Database Description", "Link State Request", etc.
+/// ```
+pub fn create_ospf_packet_type_name_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(OspfPacketTypeNameUdf::new())
+}
+
+/// Create the `ospf_lsa_type_name()` UDF.
+///
+/// # Example
+/// ```sql
+/// SELECT ospf_lsa_type_name(lsa_type) FROM ospf WHERE lsa_type IS NOT NULL;
+/// -- Returns: "Router-LSA", "Network-LSA", "Summary-LSA-Network", etc.
+/// ```
+pub fn create_ospf_lsa_type_name_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(OspfLsaTypeNameUdf::new())
+}
+
+// ============================================================================
+// ospf_packet_type_name() UDF Implementation
+// ============================================================================
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct OspfPacketTypeNameUdf {
+    signature: Signature,
+}
+
+impl OspfPacketTypeNameUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::UInt8], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for OspfPacketTypeNameUdf {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "ospf_packet_type_name"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        let values = args[0]
+            .as_any()
+            .downcast_ref::<UInt8Array>()
+            .expect("ospf_packet_type_name: expected uint8 array");
+
+        let result: StringArray = values
+            .iter()
+            .map(|opt| opt.map(ospf_packet_type_to_name))
+            .collect();
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    }
+}
+
+fn ospf_packet_type_to_name(pkt_type: u8) -> String {
+    match pkt_type {
+        packet_type::HELLO => "Hello".to_string(),
+        packet_type::DATABASE_DESCRIPTION => "Database Description".to_string(),
+        packet_type::LINK_STATE_REQUEST => "Link State Request".to_string(),
+        packet_type::LINK_STATE_UPDATE => "Link State Update".to_string(),
+        packet_type::LINK_STATE_ACK => "Link State Acknowledgment".to_string(),
+        _ => format!("Unknown ({pkt_type})"),
+    }
+}
+
+// ============================================================================
+// ospf_lsa_type_name() UDF Implementation
+// ============================================================================
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct OspfLsaTypeNameUdf {
+    signature: Signature,
+}
+
+impl OspfLsaTypeNameUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::UInt8], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for OspfLsaTypeNameUdf {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "ospf_lsa_type_name"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        let values = args[0]
+            .as_any()
+            .downcast_ref::<UInt8Array>()
+            .expect("ospf_lsa_type_name: expected uint8 array");
+
+        let result: StringArray = values
+            .iter()
+            .map(|opt| opt.map(ospf_lsa_type_to_name))
+            .collect();
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    }
+}
+
+fn ospf_lsa_type_to_name(ls_type: u8) -> String {
+    match ls_type {
+        lsa_type::ROUTER => "Router-LSA".to_string(),
+        lsa_type::NETWORK => "Network-LSA".to_string(),
+        lsa_type::SUMMARY_NETWORK => "Summary-LSA-Network".to_string(),
+        lsa_type::SUMMARY_ASBR => "Summary-LSA-ASBR".to_string(),
+        lsa_type::AS_EXTERNAL => "AS-External-LSA".to_string(),
+        lsa_type::GROUP_MEMBERSHIP => "Group-Membership-LSA".to_string(),
+        lsa_type::NSSA_EXTERNAL => "NSSA-External-LSA".to_string(),
+        lsa_type::EXTERNAL_ATTRIBUTES => "External-Attributes-LSA".to_string(),
+        lsa_type::OPAQUE_LINK => "Opaque-Link-LSA".to_string(),
+        lsa_type::OPAQUE_AREA => "Opaque-Area-LSA".to_string(),
+        lsa_type::OPAQUE_AS => "Opaque-AS-LSA".to_string(),
+        _ => format!("Unknown ({ls_type})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ospf_packet_type_name() {
+        assert_eq!(ospf_packet_type_to_name(packet_type::HELLO), "Hello");
+        assert_eq!(
+            ospf_packet_type_to_name(packet_type::DATABASE_DESCRIPTION),
+            "Database Description"
+        );
+        assert_eq!(
+            ospf_packet_type_to_name(packet_type::LINK_STATE_REQUEST),
+            "Link State Request"
+        );
+        assert_eq!(
+            ospf_packet_type_to_name(packet_type::LINK_STATE_UPDATE),
+            "Link State Update"
+        );
+        assert_eq!(
+            ospf_packet_type_to_name(packet_type::LINK_STATE_ACK),
+            "Link State Acknowledgment"
+        );
+        assert_eq!(ospf_packet_type_to_name(99), "Unknown (99)");
+    }
+
+    #[test]
+    fn test_ospf_lsa_type_name() {
+        assert_eq!(ospf_lsa_type_to_name(lsa_type::ROUTER), "Router-LSA");
+        assert_eq!(ospf_lsa_type_to_name(lsa_type::NETWORK), "Network-LSA");
+        assert_eq!(
+            ospf_lsa_type_to_name(lsa_type::AS_EXTERNAL),
+            "AS-External-LSA"
+        );
+        assert_eq!(
+            ospf_lsa_type_to_name(lsa_type::NSSA_EXTERNAL),
+            "NSSA-External-LSA"
+        );
+        assert_eq!(ospf_lsa_type_to_name(99), "Unknown (99)");
+    }
+}

--- a/pcapsql-datafusion/src/query/udf/tls_proto.rs
+++ b/pcapsql-datafusion/src/query/udf/tls_proto.rs
@@ -1,0 +1,196 @@
+//! TLS protocol UDFs.
+//!
+//! Provides functions for converting TLS version and record types to human-readable names.
+//! Uses protocol constants from pcapsql-core for consistency.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, StringArray, UInt16Array, UInt8Array};
+use arrow::datatypes::DataType;
+use datafusion::common::Result as DFResult;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use pcapsql_core::protocol::{tls_record_type as record_type, tls_version as version};
+
+/// Create the `tls_version_name()` UDF.
+///
+/// # Example
+/// ```sql
+/// SELECT tls_version_name(record_version) FROM tls;
+/// -- Returns: "TLS 1.0", "TLS 1.2", "TLS 1.3", etc.
+/// ```
+pub fn create_tls_version_name_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(TlsVersionNameUdf::new())
+}
+
+/// Create the `tls_record_type_name()` UDF.
+///
+/// # Example
+/// ```sql
+/// SELECT tls_record_type_name(record_type) FROM tls;
+/// -- Returns: "ChangeCipherSpec", "Alert", "Handshake", "ApplicationData"
+/// ```
+pub fn create_tls_record_type_name_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(TlsRecordTypeNameUdf::new())
+}
+
+// ============================================================================
+// tls_version_name() UDF Implementation
+// ============================================================================
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct TlsVersionNameUdf {
+    signature: Signature,
+}
+
+impl TlsVersionNameUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::UInt16], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for TlsVersionNameUdf {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "tls_version_name"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        let values = args[0]
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("tls_version_name: expected uint16 array");
+
+        let result: StringArray = values
+            .iter()
+            .map(|opt| opt.map(tls_version_to_name))
+            .collect();
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    }
+}
+
+fn tls_version_to_name(ver: u16) -> String {
+    match ver {
+        version::SSL_2_0 => "SSL 2.0".to_string(),
+        version::SSL_3_0 => "SSL 3.0".to_string(),
+        version::TLS_1_0 => "TLS 1.0".to_string(),
+        version::TLS_1_1 => "TLS 1.1".to_string(),
+        version::TLS_1_2 => "TLS 1.2".to_string(),
+        version::TLS_1_3 => "TLS 1.3".to_string(),
+        // GREASE values (RFC 8701) - pattern 0x?a?a
+        v if (v & 0x0f0f) == 0x0a0a => "GREASE".to_string(),
+        _ => format!("Unknown (0x{ver:04x})"),
+    }
+}
+
+// ============================================================================
+// tls_record_type_name() UDF Implementation
+// ============================================================================
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct TlsRecordTypeNameUdf {
+    signature: Signature,
+}
+
+impl TlsRecordTypeNameUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::UInt8], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for TlsRecordTypeNameUdf {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "tls_record_type_name"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(&args.args)?;
+        let values = args[0]
+            .as_any()
+            .downcast_ref::<UInt8Array>()
+            .expect("tls_record_type_name: expected uint8 array");
+
+        let result: StringArray = values
+            .iter()
+            .map(|opt| opt.map(tls_record_type_to_name))
+            .collect();
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    }
+}
+
+fn tls_record_type_to_name(rt: u8) -> String {
+    match rt {
+        record_type::CHANGE_CIPHER_SPEC => "ChangeCipherSpec".to_string(),
+        record_type::ALERT => "Alert".to_string(),
+        record_type::HANDSHAKE => "Handshake".to_string(),
+        record_type::APPLICATION_DATA => "ApplicationData".to_string(),
+        record_type::HEARTBEAT => "Heartbeat".to_string(),
+        _ => format!("Unknown ({rt})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tls_version_name() {
+        assert_eq!(tls_version_to_name(version::SSL_2_0), "SSL 2.0");
+        assert_eq!(tls_version_to_name(version::SSL_3_0), "SSL 3.0");
+        assert_eq!(tls_version_to_name(version::TLS_1_0), "TLS 1.0");
+        assert_eq!(tls_version_to_name(version::TLS_1_1), "TLS 1.1");
+        assert_eq!(tls_version_to_name(version::TLS_1_2), "TLS 1.2");
+        assert_eq!(tls_version_to_name(version::TLS_1_3), "TLS 1.3");
+        // GREASE values
+        assert_eq!(tls_version_to_name(0x0a0a), "GREASE");
+        assert_eq!(tls_version_to_name(0x1a1a), "GREASE");
+        assert_eq!(tls_version_to_name(0xfafa), "GREASE");
+        // Unknown
+        assert_eq!(tls_version_to_name(0x0305), "Unknown (0x0305)");
+    }
+
+    #[test]
+    fn test_tls_record_type_name() {
+        assert_eq!(
+            tls_record_type_to_name(record_type::CHANGE_CIPHER_SPEC),
+            "ChangeCipherSpec"
+        );
+        assert_eq!(tls_record_type_to_name(record_type::ALERT), "Alert");
+        assert_eq!(tls_record_type_to_name(record_type::HANDSHAKE), "Handshake");
+        assert_eq!(
+            tls_record_type_to_name(record_type::APPLICATION_DATA),
+            "ApplicationData"
+        );
+        assert_eq!(tls_record_type_to_name(record_type::HEARTBEAT), "Heartbeat");
+        assert_eq!(tls_record_type_to_name(99), "Unknown (99)");
+    }
+}


### PR DESCRIPTION
## Summary

Add UDFs for converting protocol-specific numeric values to human-readable names, implementing Tier 1 and Tier 2 

### Tier 1 - Protocol Enumeration UDFs
- `bgp_message_type_name()`: OPEN, UPDATE, NOTIFICATION, KEEPALIVE, ROUTE-REFRESH
- `bgp_origin_name()`: IGP, EGP, INCOMPLETE
- `ospf_packet_type_name()`: Hello, Database Description, LS Request/Update/Ack
- `ospf_lsa_type_name()`: Router-LSA, Network-LSA, Summary-LSA, etc.
- `gtp_message_type_name()`: Echo Request/Response, G-PDU, Create Session, etc.
- `ntp_mode_name()`: Client, Server, Broadcast, Symmetric Active/Passive
- `ntp_stratum_name()`: Unspecified, Primary, Secondary (stratum N)
- `tls_version_name()`: SSL 2.0/3.0, TLS 1.0/1.1/1.2/1.3
- `tls_record_type_name()`: ChangeCipherSpec, Alert, Handshake, ApplicationData

### Tier 2 - ICMP Code Detail UDFs
- `icmp_code_name(type, code)`: Detailed ICMP codes (e.g., "Port Unreachable")
- `icmpv6_code_name(type, code)`: Detailed ICMPv6 codes (e.g., "No Route to Destination")

### Protocol Constants
Adds protocol constants to pcapsql-core for use in UDFs and protocol parsers:
- ICMP/ICMPv6 dest_unreachable_code, redirect_code, time_exceeded_code, parameter_problem_code
- GTP message_type (27 message types)
- TLS version, record_type, and alert modules
- OSPF additional lsa_type constants (6-11)

All UDFs use protocol constants from pcapsql-core instead of magic numbers, ensuring consistency with the protocol parser implementations.

## Test plan

- [x] All existing tests pass (993+ tests)
- [x] New UDF unit tests for all protocol name functions
- [x] Tests use protocol constants to validate correct mappings

Closes #69, #70