### PR TITLE
Stage 3/9 — Reader: nanosecond timestamps, per-interface tsresol, robust edges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3487,6 +3487,7 @@ dependencies = [
  "nom 7.1.3",
  "object_store 0.11.2",
  "pcap-parser",
+ "pcapsql-testgen",
  "ring",
  "simple-dns",
  "smallvec",

--- a/pcapsql-core/Cargo.toml
+++ b/pcapsql-core/Cargo.toml
@@ -89,3 +89,4 @@ netlink-packet-utils.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 hex.workspace = true
+pcapsql-testgen.workspace = true

--- a/pcapsql-core/src/io/mmap.rs
+++ b/pcapsql-core/src/io/mmap.rs
@@ -510,7 +510,7 @@ mod tests {
                 assert_eq!(packet.frame_number, 1);
 
                 // Timestamp should be positive (after Unix epoch)
-                assert!(packet.timestamp_us > 0);
+                assert!(packet.timestamp_ns > 0);
                 Ok(())
             })
             .unwrap();
@@ -568,19 +568,19 @@ mod tests {
             let processed = reader
                 .process_packets(100, |packet| {
                     // Timestamps should be non-negative
-                    assert!(packet.timestamp_us >= 0);
+                    assert!(packet.timestamp_ns >= 0);
 
                     // Timestamps should generally not go backwards (within reason)
                     // Allow small backward jumps for clock drift
                     if prev_timestamp > 0 {
-                        let diff = packet.timestamp_us - prev_timestamp;
+                        let diff = packet.timestamp_ns - prev_timestamp;
                         assert!(
-                            diff >= -1_000_000, // Allow up to 1 second backward
-                            "Timestamp went backwards by {} us",
+                            diff >= -1_000_000_000, // Allow up to 1 second backward
+                            "Timestamp went backwards by {} ns",
                             diff.abs()
                         );
                     }
-                    prev_timestamp = packet.timestamp_us;
+                    prev_timestamp = packet.timestamp_ns;
                     Ok(())
                 })
                 .unwrap();

--- a/pcapsql-core/src/io/mod.rs
+++ b/pcapsql-core/src/io/mod.rs
@@ -39,7 +39,7 @@ pub use decompress::{decompress_header, Compression, DecompressReader, FileDecod
 pub use decompress::{AnyDecoder, MmapSlice};
 #[cfg(feature = "mmap")]
 pub use mmap::{MmapPacketReader, MmapPacketSource};
-pub use pcap_stream::{GenericPcapReader, PcapFormat};
+pub use pcap_stream::{GenericPcapReader, InterfaceInfo, InterfaceState, PcapFormat};
 pub use source::{
     FilePacketReader, FilePacketSource, PacketPosition, PacketRange, PacketReader, PacketRef,
     PacketSource, PacketSourceMetadata, RawPacket,

--- a/pcapsql-core/src/io/pcap_stream.rs
+++ b/pcapsql-core/src/io/pcap_stream.rs
@@ -1,36 +1,98 @@
 //! Generic PCAP/PCAPNG reader over any Read source.
 //!
 //! This module provides a unified PCAP parser that works with any `R: Read` source,
-//! using the battle-tested `pcap_parser` crate. Benchmarks show this approach is
-//! actually 30% faster than custom byte parsing while being more maintainable.
+//! using the `pcap_parser` crate.
 //!
-//! ## Usage
+//! ## Timestamps
 //!
-//! ```ignore
-//! use std::fs::File;
-//! use std::io::Cursor;
+//! Packet timestamps are decoded to **nanoseconds since the Unix epoch** (`i64`).
+//! For legacy PCAP the sub-second field is interpreted per the magic (microseconds
+//! or nanoseconds). For PCAPNG the per-interface `if_tsresol` is honored, so a
+//! capture mixing microsecond- and nanosecond-resolution interfaces decodes
+//! correctly. This per-interface state is exactly what a mid-file partition needs,
+//! and is what the boundary index persists in each checkpoint.
 //!
-//! // From a file with known format
-//! let file = File::open("capture.pcap")?;
-//! let reader = GenericPcapReader::with_format(file, PcapFormat::LegacyLeMicro)?;
+//! ## Mid-file / headerless starts
 //!
-//! // From memory-mapped data
-//! let mmap = Arc::new(unsafe { Mmap::map(&file)? });
-//! let cursor = Cursor::new(MmapSlice::new(mmap));
-//! let reader = GenericPcapReader::with_format(cursor, PcapFormat::LegacyLeMicro)?;
-//! ```
+//! [`GenericPcapReader::with_format_starting_at`] constructs a reader whose first
+//! frame is numbered `start_frame` instead of 1. The caller is responsible for
+//! supplying a byte stream that begins with a (real or synthesized) header
+//! followed by record data at a record boundary — see [`crate::io::index`] for the
+//! header synthesis used by seekable sources.
 
 use std::io::{BufReader, Read};
 
 use bytes::Bytes;
-use pcap_parser::traits::PcapReaderIterator;
-use pcap_parser::{LegacyPcapReader, PcapBlockOwned, PcapNGReader};
+use pcap_parser::pcapng::{build_ts_resolution, Block};
+use pcap_parser::traits::{PcapNGPacketBlock, PcapReaderIterator};
+use pcap_parser::{LegacyPcapReader, PcapBlockOwned, PcapError as PcapParserError, PcapNGReader};
 
 use crate::error::{Error, PcapError};
 use crate::io::{PacketRef, RawPacket};
 
-/// Buffer size for pcap_parser readers (64KB).
+/// Initial buffer size for pcap_parser readers (256 KiB).
+///
+/// Frames larger than this are handled by growing the buffer on demand (see the
+/// `BufferTooSmall` handling in the read loops).
 const BUFFER_SIZE: usize = 262144;
+
+/// Default timestamp resolution (units per second) when none is known: microseconds.
+const DEFAULT_RESOLUTION: u64 = 1_000_000;
+
+/// Per-interface state required to interpret packets (PCAPNG).
+///
+/// For legacy PCAP there is a single implicit interface; this type is used for
+/// PCAPNG where each Interface Description Block introduces one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InterfaceInfo {
+    /// Link-layer type for packets on this interface.
+    pub link_type: u32,
+    /// `if_tsresol` raw byte (decimal exponent, or binary if high bit set).
+    pub if_tsresol: u8,
+    /// Snapshot length declared for this interface.
+    pub snaplen: u32,
+}
+
+impl InterfaceInfo {
+    /// Timestamp resolution in units per second (e.g. 1_000_000 for microseconds).
+    #[inline]
+    pub fn resolution(&self) -> u64 {
+        build_ts_resolution(self.if_tsresol).unwrap_or(DEFAULT_RESOLUTION)
+    }
+}
+
+/// The full interface table in effect at a point in a PCAPNG stream.
+///
+/// Persisted in boundary-index checkpoints so a partition starting mid-file can
+/// reconstruct the interfaces (link type + `if_tsresol`) it needs.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct InterfaceState {
+    /// Interfaces in declaration order; index == PCAPNG interface id within the section.
+    pub interfaces: Vec<InterfaceInfo>,
+}
+
+/// Convert a legacy timestamp (seconds + sub-second field) to nanoseconds.
+#[inline]
+pub(crate) fn ns_from_legacy(ts_sec: u32, ts_frac: u32, nano: bool) -> i64 {
+    let sub_ns = if nano {
+        ts_frac as i64
+    } else {
+        (ts_frac as i64) * 1_000
+    };
+    (ts_sec as i64) * 1_000_000_000 + sub_ns
+}
+
+/// Convert PCAPNG timestamp ticks to nanoseconds given the interface resolution.
+#[inline]
+pub(crate) fn ns_from_ticks(ts_high: u32, ts_low: u32, resolution: u64) -> i64 {
+    let ticks = ((ts_high as u128) << 32) | (ts_low as u128);
+    let res = if resolution == 0 {
+        DEFAULT_RESOLUTION
+    } else {
+        resolution
+    } as u128;
+    (ticks * 1_000_000_000u128 / res) as i64
+}
 
 /// Format of the PCAP file.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -48,7 +110,11 @@ pub enum PcapFormat {
 }
 
 impl PcapFormat {
-    /// Detect PCAP format from magic bytes.
+    /// Detect PCAP format from the file's leading magic bytes.
+    ///
+    /// Matches the on-disk byte sequence directly, so detection is independent
+    /// of the host's endianness. (Decoding the magic as a host-order integer
+    /// would swap the LE/BE variants when running on a big-endian host.)
     pub fn detect(data: &[u8]) -> Result<Self, Error> {
         if data.len() < 4 {
             return Err(Error::Pcap(PcapError::InvalidFormat {
@@ -56,16 +122,17 @@ impl PcapFormat {
             }));
         }
 
-        let magic = u32::from_ne_bytes([data[0], data[1], data[2], data[3]]);
-
-        match magic {
-            0xa1b2c3d4 => Ok(PcapFormat::LegacyLeMicro),
-            0xd4c3b2a1 => Ok(PcapFormat::LegacyBeMicro),
-            0xa1b23c4d => Ok(PcapFormat::LegacyLeNano),
-            0x4d3cb2a1 => Ok(PcapFormat::LegacyBeNano),
-            0x0a0d0d0a => Ok(PcapFormat::PcapNg),
-            _ => Err(Error::Pcap(PcapError::InvalidFormat {
-                reason: format!("Unknown PCAP magic: 0x{magic:08x}"),
+        match [data[0], data[1], data[2], data[3]] {
+            // Legacy magic 0xA1B2C3D4 (microseconds) written by LE / BE hosts.
+            [0xd4, 0xc3, 0xb2, 0xa1] => Ok(PcapFormat::LegacyLeMicro),
+            [0xa1, 0xb2, 0xc3, 0xd4] => Ok(PcapFormat::LegacyBeMicro),
+            // Legacy magic 0xA1B23C4D (nanoseconds) written by LE / BE hosts.
+            [0x4d, 0x3c, 0xb2, 0xa1] => Ok(PcapFormat::LegacyLeNano),
+            [0xa1, 0xb2, 0x3c, 0x4d] => Ok(PcapFormat::LegacyBeNano),
+            // PCAPNG Section Header Block type (palindromic across endianness).
+            [0x0a, 0x0d, 0x0d, 0x0a] => Ok(PcapFormat::PcapNg),
+            other => Err(Error::Pcap(PcapError::InvalidFormat {
+                reason: format!("Unknown PCAP magic: {other:02x?}"),
             })),
         }
     }
@@ -80,28 +147,41 @@ impl PcapFormat {
         !self.is_pcapng()
     }
 
+    /// Whether the legacy sub-second field is nanoseconds (vs microseconds).
+    pub fn legacy_is_nano(&self) -> bool {
+        matches!(self, PcapFormat::LegacyLeNano | PcapFormat::LegacyBeNano)
+    }
+
+    /// Whether this format uses big-endian byte order on disk.
+    pub fn is_big_endian(&self) -> bool {
+        matches!(self, PcapFormat::LegacyBeMicro | PcapFormat::LegacyBeNano)
+    }
+
     /// Whether this format uses little-endian byte order.
-    ///
-    /// This is relevant for parsing header fields like link_type.
-    /// For PCAPNG, the section header defines endianness, but we assume
-    /// little-endian as it's the most common case.
     pub fn is_little_endian(&self) -> bool {
+        !self.is_big_endian()
+    }
+
+    /// The 32-bit magic value for a legacy format (host-order u32).
+    pub fn legacy_magic_u32(&self) -> u32 {
         match self {
-            PcapFormat::LegacyLeMicro | PcapFormat::LegacyLeNano => true,
-            PcapFormat::LegacyBeMicro | PcapFormat::LegacyBeNano => false,
-            PcapFormat::PcapNg => true, // Most PCAPNG files are little-endian
+            PcapFormat::LegacyLeMicro | PcapFormat::LegacyBeMicro => 0xa1b2_c3d4,
+            PcapFormat::LegacyLeNano | PcapFormat::LegacyBeNano => 0xa1b2_3c4d,
+            PcapFormat::PcapNg => 0x0a0d_0d0a,
         }
     }
 }
 
 /// Generic PCAP/PCAPNG reader over any Read source.
-///
-/// This is the unified PCAP parser that uses `pcap_parser` for all formats.
-/// It provides a simple `next_packet()` interface that works with any byte source.
 pub struct GenericPcapReader<R: Read> {
     inner: ReaderInner<R>,
+    format: PcapFormat,
     frame_number: u64,
     link_type: u32,
+    /// PCAPNG interface table for the current section (empty for legacy).
+    interfaces: Vec<InterfaceInfo>,
+    /// Current buffer capacity, grown on demand for oversized frames.
+    capacity: usize,
 }
 
 /// Inner reader using enum dispatch for format-specific handling.
@@ -111,52 +191,63 @@ enum ReaderInner<R: Read> {
 }
 
 impl<R: Read> GenericPcapReader<R> {
-    /// Create a reader with known format.
+    /// Create a reader with known format, starting at frame 1.
     ///
-    /// This is the primary constructor. Use `PcapFormat::detect()` to determine
-    /// the format from magic bytes before calling this.
-    ///
-    /// Note: For legacy PCAP, the header is read during construction to extract
-    /// the link_type. For PCAPNG, link_type is initially 1 and gets updated when
-    /// the Interface Description Block is read during packet processing.
+    /// The byte stream must begin with the appropriate header (legacy global
+    /// header, or PCAPNG section header block).
     pub fn with_format(source: R, format: PcapFormat) -> Result<Self, Error> {
+        Self::build(source, format, 0)
+    }
+
+    /// Create a reader whose first emitted frame is numbered `start_frame`.
+    ///
+    /// Used for mid-file partitions: the supplied byte stream must begin with a
+    /// real or synthesized header (so link type / interface state are
+    /// established) followed by record data at a record boundary.
+    pub fn with_format_starting_at(
+        source: R,
+        format: PcapFormat,
+        start_frame: u64,
+    ) -> Result<Self, Error> {
+        let prev = start_frame.saturating_sub(1);
+        Self::build(source, format, prev)
+    }
+
+    fn build(source: R, format: PcapFormat, initial_frame: u64) -> Result<Self, Error> {
         let buf_reader = BufReader::with_capacity(BUFFER_SIZE, source);
 
         let (inner, link_type) = if format.is_pcapng() {
             let reader = PcapNGReader::new(BUFFER_SIZE, buf_reader).map_err(|e| {
                 Error::Pcap(PcapError::InvalidFormat {
-                    reason: format!("Failed to parse PCAPNG: {e}"),
+                    reason: format!("Failed to parse PCAPNG: {e:?}"),
                 })
             })?;
-            // PCAPNG link_type comes from IDB block, read during packet processing
             (ReaderInner::Ng(reader), 1u32)
         } else {
             let mut reader = LegacyPcapReader::new(BUFFER_SIZE, buf_reader).map_err(|e| {
                 Error::Pcap(PcapError::InvalidFormat {
-                    reason: format!("Failed to parse legacy PCAP: {e}"),
+                    reason: format!("Failed to parse legacy PCAP: {e:?}"),
                 })
             })?;
-            // Read ahead to get link_type from the legacy PCAP header
             let link_type = Self::read_legacy_header_link_type(&mut reader)?;
             (ReaderInner::Legacy(reader), link_type)
         };
 
         Ok(GenericPcapReader {
             inner,
-            frame_number: 0,
+            format,
+            frame_number: initial_frame,
             link_type,
+            interfaces: Vec::new(),
+            capacity: BUFFER_SIZE,
         })
     }
 
-    /// Read the legacy PCAP header to extract link_type.
-    ///
-    /// This consumes the header block but leaves the reader positioned
-    /// at the first packet.
+    /// Read the legacy PCAP header to extract link_type, leaving the reader
+    /// positioned at the first packet record.
     fn read_legacy_header_link_type<S: Read>(
         reader: &mut LegacyPcapReader<S>,
     ) -> Result<u32, Error> {
-        use pcap_parser::PcapError as PcapParserError;
-
         loop {
             match reader.next() {
                 Ok((offset, block)) => match block {
@@ -166,286 +257,183 @@ impl<R: Read> GenericPcapReader<R> {
                         return Ok(link_type);
                     }
                     PcapBlockOwned::Legacy(_) => {
-                        // Shouldn't happen - header should come first
-                        // Don't consume, let normal reading handle it
-                        return Ok(1); // Default to Ethernet
+                        // Header already consumed elsewhere; default to Ethernet.
+                        return Ok(1);
                     }
                     _ => {
                         reader.consume(offset);
                         continue;
                     }
                 },
-                Err(PcapParserError::Eof) => {
-                    return Ok(1); // Empty file, default to Ethernet
-                }
+                Err(PcapParserError::Eof) | Err(PcapParserError::UnexpectedEof) => return Ok(1),
                 Err(PcapParserError::Incomplete(_)) => {
                     reader.refill().map_err(|e| {
                         Error::Pcap(PcapError::InvalidFormat {
-                            reason: format!("Failed to read PCAP header: {e}"),
+                            reason: format!("Failed to read PCAP header: {e:?}"),
                         })
                     })?;
                     continue;
                 }
                 Err(e) => {
                     return Err(Error::Pcap(PcapError::InvalidFormat {
-                        reason: format!("Failed to parse PCAP header: {e}"),
+                        reason: format!("Failed to parse PCAP header: {e:?}"),
                     }));
                 }
             }
         }
     }
 
-    /// Read the next packet.
-    ///
-    /// Returns `Ok(None)` at end of file.
+    /// Read the next packet (copying API).
     pub fn next_packet(&mut self) -> Result<Option<RawPacket>, Error> {
-        match &mut self.inner {
-            ReaderInner::Legacy(reader) => {
-                read_legacy_packet(reader, &mut self.frame_number, &mut self.link_type)
-            }
-            ReaderInner::Ng(reader) => {
-                read_pcapng_packet(reader, &mut self.frame_number, &mut self.link_type)
-            }
-        }
+        let mut out = None;
+        self.process_packets(1, |p| {
+            out = Some(RawPacket::from_bytes(
+                p.frame_number,
+                p.timestamp_ns,
+                p.captured_len,
+                p.original_len,
+                p.link_type,
+                Bytes::copy_from_slice(p.data),
+            ));
+            Ok(())
+        })?;
+        Ok(out)
     }
 
-    /// Get the link type (e.g., 1 = Ethernet).
+    /// Get the link type (e.g., 1 = Ethernet). For PCAPNG this reflects the most
+    /// recently seen interface.
     pub fn link_type(&self) -> u32 {
         self.link_type
     }
 
-    /// Get the current frame count.
+    /// Get the current frame count (number of packets emitted so far, offset by
+    /// the starting frame for mid-file readers).
     pub fn frame_count(&self) -> u64 {
         self.frame_number
     }
 
-    /// Process packets with zero-copy borrowed data.
-    ///
-    /// The callback receives borrowed packet data. The borrow is valid
-    /// only during the callback - data must be processed before returning.
-    /// This eliminates the `Bytes::copy_from_slice()` overhead of `next_packet()`.
-    ///
-    /// Returns the number of packets processed.
+    /// Number of bytes consumed from the underlying stream so far.
+    pub fn consumed_bytes(&self) -> u64 {
+        match &self.inner {
+            ReaderInner::Legacy(r) => r.consumed() as u64,
+            ReaderInner::Ng(r) => r.consumed() as u64,
+        }
+    }
+
+    /// Snapshot of the current PCAPNG interface table.
+    pub fn interface_state(&self) -> InterfaceState {
+        InterfaceState {
+            interfaces: self.interfaces.clone(),
+        }
+    }
+
+    /// Process up to `max` packets, invoking `f` with borrowed packet data.
     #[inline]
     pub fn process_packets<F>(&mut self, max: usize, f: F) -> Result<usize, Error>
     where
         F: FnMut(PacketRef<'_>) -> Result<(), Error>,
     {
+        let nano = self.format.legacy_is_nano();
         match &mut self.inner {
-            ReaderInner::Legacy(reader) => {
-                process_legacy_packets(reader, max, &mut self.frame_number, &mut self.link_type, f)
-            }
-            ReaderInner::Ng(reader) => {
-                process_pcapng_packets(reader, max, &mut self.frame_number, &mut self.link_type, f)
-            }
+            ReaderInner::Legacy(reader) => process_legacy_packets(
+                reader,
+                max,
+                &mut self.frame_number,
+                &mut self.link_type,
+                nano,
+                &mut self.capacity,
+                f,
+            ),
+            ReaderInner::Ng(reader) => process_pcapng_packets(
+                reader,
+                max,
+                &mut self.frame_number,
+                &mut self.link_type,
+                &mut self.interfaces,
+                &mut self.capacity,
+                f,
+            ),
         }
     }
 }
 
-/// Read next packet from a legacy PCAP reader.
-fn read_legacy_packet<S: Read>(
-    reader: &mut LegacyPcapReader<S>,
-    frame_number: &mut u64,
-    link_type: &mut u32,
-) -> Result<Option<RawPacket>, Error> {
-    use pcap_parser::PcapError as PcapParserError;
-
-    loop {
-        match reader.next() {
-            Ok((offset, block)) => match block {
-                PcapBlockOwned::Legacy(packet) => {
-                    *frame_number += 1;
-
-                    let timestamp_us = (packet.ts_sec as i64) * 1_000_000 + (packet.ts_usec as i64);
-
-                    let raw = RawPacket {
-                        frame_number: *frame_number,
-                        timestamp_us,
-                        captured_length: packet.caplen,
-                        original_length: packet.origlen,
-                        link_type: *link_type as u16,
-                        data: Bytes::copy_from_slice(packet.data),
-                    };
-
-                    reader.consume(offset);
-                    return Ok(Some(raw));
-                }
-                PcapBlockOwned::LegacyHeader(header) => {
-                    *link_type = header.network.0 as u32;
-                    reader.consume(offset);
-                    continue;
-                }
-                _ => {
-                    reader.consume(offset);
-                    continue;
-                }
-            },
-            Err(PcapParserError::Eof) => return Ok(None),
-            Err(PcapParserError::Incomplete(_)) => {
-                reader.refill().map_err(|e| {
-                    Error::Pcap(PcapError::InvalidFormat {
-                        reason: format!("Legacy PCAP refill error: {e}"),
-                    })
-                })?;
-                continue;
-            }
-            Err(e) => {
-                return Err(Error::Pcap(PcapError::InvalidFormat {
-                    reason: format!("Legacy PCAP parse error: {e}"),
-                }));
-            }
-        }
+/// Grow the buffer to fit a frame larger than the current capacity.
+fn grow_buffer<I: PcapReaderIterator>(
+    reader: &mut I,
+    capacity: &mut usize,
+    what: &str,
+) -> Result<(), Error> {
+    let new_cap = capacity.saturating_mul(2);
+    if new_cap == *capacity || !reader.grow(new_cap) {
+        return Err(Error::Pcap(PcapError::InvalidFormat {
+            reason: format!("{what}: frame exceeds maximum buffer size"),
+        }));
     }
-}
-
-/// Read next packet from a PCAPNG reader.
-fn read_pcapng_packet<S: Read>(
-    reader: &mut PcapNGReader<S>,
-    frame_number: &mut u64,
-    link_type: &mut u32,
-) -> Result<Option<RawPacket>, Error> {
-    use pcap_parser::PcapError as PcapParserError;
-
-    loop {
-        match reader.next() {
-            Ok((offset, block)) => match block {
-                PcapBlockOwned::NG(ng_block) => {
-                    use pcap_parser::pcapng::*;
-
-                    match ng_block {
-                        Block::InterfaceDescription(idb) => {
-                            *link_type = idb.linktype.0 as u32;
-                            reader.consume(offset);
-                            continue;
-                        }
-                        Block::EnhancedPacket(epb) => {
-                            *frame_number += 1;
-
-                            let timestamp_us = ((epb.ts_high as i64) << 32) | (epb.ts_low as i64);
-
-                            let packet = RawPacket {
-                                frame_number: *frame_number,
-                                timestamp_us,
-                                captured_length: epb.caplen,
-                                original_length: epb.origlen,
-                                link_type: *link_type as u16,
-                                data: Bytes::copy_from_slice(epb.data),
-                            };
-
-                            reader.consume(offset);
-                            return Ok(Some(packet));
-                        }
-                        Block::SimplePacket(spb) => {
-                            *frame_number += 1;
-
-                            let packet = RawPacket {
-                                frame_number: *frame_number,
-                                timestamp_us: 0,
-                                captured_length: spb.data.len() as u32,
-                                original_length: spb.origlen,
-                                link_type: *link_type as u16,
-                                data: Bytes::copy_from_slice(spb.data),
-                            };
-
-                            reader.consume(offset);
-                            return Ok(Some(packet));
-                        }
-                        _ => {
-                            reader.consume(offset);
-                            continue;
-                        }
-                    }
-                }
-                _ => {
-                    reader.consume(offset);
-                    continue;
-                }
-            },
-            Err(PcapParserError::Eof) => return Ok(None),
-            Err(PcapParserError::Incomplete(_)) => {
-                reader.refill().map_err(|e| {
-                    Error::Pcap(PcapError::InvalidFormat {
-                        reason: format!("PCAPNG refill error: {e}"),
-                    })
-                })?;
-                continue;
-            }
-            Err(e) => {
-                return Err(Error::Pcap(PcapError::InvalidFormat {
-                    reason: format!("PCAPNG parse error: {e}"),
-                }));
-            }
-        }
-    }
+    *capacity = new_cap;
+    reader.refill().map_err(|e| {
+        Error::Pcap(PcapError::InvalidFormat {
+            reason: format!("{what} refill error: {e:?}"),
+        })
+    })
 }
 
 /// Process packets from a legacy PCAP reader with zero-copy.
-///
-/// This is the zero-copy version of `read_legacy_packet`. The callback receives
-/// borrowed packet data that must be processed before returning.
+#[allow(clippy::too_many_arguments)]
 fn process_legacy_packets<S: Read, F>(
     reader: &mut LegacyPcapReader<S>,
     max: usize,
     frame_number: &mut u64,
     link_type: &mut u32,
+    nano: bool,
+    capacity: &mut usize,
     mut f: F,
 ) -> Result<usize, Error>
 where
     F: FnMut(PacketRef<'_>) -> Result<(), Error>,
 {
-    use pcap_parser::PcapError as PcapParserError;
-
     let mut count = 0;
     while count < max {
         match reader.next() {
-            Ok((offset, block)) => {
-                match block {
-                    PcapBlockOwned::Legacy(packet) => {
-                        *frame_number += 1;
-
-                        let timestamp_us =
-                            (packet.ts_sec as i64) * 1_000_000 + (packet.ts_usec as i64);
-
-                        // Create borrowed packet reference - no copy!
-                        let packet_ref = PacketRef {
-                            frame_number: *frame_number,
-                            timestamp_us,
-                            captured_len: packet.caplen,
-                            original_len: packet.origlen,
-                            link_type: *link_type as u16,
-                            data: packet.data, // Borrowed from pcap_parser buffer
-                        };
-
-                        // Call the callback with borrowed data
-                        f(packet_ref)?;
-
-                        // Only consume after callback completes
-                        reader.consume(offset);
-                        count += 1;
-                    }
-                    PcapBlockOwned::LegacyHeader(header) => {
-                        *link_type = header.network.0 as u32;
-                        reader.consume(offset);
-                        continue;
-                    }
-                    _ => {
-                        reader.consume(offset);
-                        continue;
-                    }
+            Ok((offset, block)) => match block {
+                PcapBlockOwned::Legacy(packet) => {
+                    *frame_number += 1;
+                    let timestamp_ns = ns_from_legacy(packet.ts_sec, packet.ts_usec, nano);
+                    let packet_ref = PacketRef {
+                        frame_number: *frame_number,
+                        timestamp_ns,
+                        captured_len: packet.caplen,
+                        original_len: packet.origlen,
+                        link_type: *link_type as u16,
+                        data: packet.data,
+                    };
+                    f(packet_ref)?;
+                    reader.consume(offset);
+                    count += 1;
                 }
-            }
-            Err(PcapParserError::Eof) => break,
+                PcapBlockOwned::LegacyHeader(header) => {
+                    *link_type = header.network.0 as u32;
+                    reader.consume(offset);
+                }
+                _ => {
+                    reader.consume(offset);
+                }
+            },
+            // Graceful stop on clean EOF and on truncated captures (declared
+            // length exceeds bytes present).
+            Err(PcapParserError::Eof) | Err(PcapParserError::UnexpectedEof) => break,
             Err(PcapParserError::Incomplete(_)) => {
                 reader.refill().map_err(|e| {
                     Error::Pcap(PcapError::InvalidFormat {
-                        reason: format!("Legacy PCAP refill error: {e}"),
+                        reason: format!("Legacy PCAP refill error: {e:?}"),
                     })
                 })?;
-                continue;
+            }
+            Err(PcapParserError::BufferTooSmall) => {
+                grow_buffer(reader, capacity, "Legacy PCAP")?;
             }
             Err(e) => {
                 return Err(Error::Pcap(PcapError::InvalidFormat {
-                    reason: format!("Legacy PCAP parse error: {e}"),
+                    reason: format!("Legacy PCAP parse error: {e:?}"),
                 }));
             }
         }
@@ -453,103 +441,105 @@ where
     Ok(count)
 }
 
-/// Process packets from a PCAPNG reader with zero-copy.
-///
-/// This is the zero-copy version of `read_pcapng_packet`. The callback receives
-/// borrowed packet data that must be processed before returning.
+/// Process packets from a PCAPNG reader with zero-copy, honoring per-interface
+/// link type and timestamp resolution.
+#[allow(clippy::too_many_arguments)]
 fn process_pcapng_packets<S: Read, F>(
     reader: &mut PcapNGReader<S>,
     max: usize,
     frame_number: &mut u64,
     link_type: &mut u32,
+    interfaces: &mut Vec<InterfaceInfo>,
+    capacity: &mut usize,
     mut f: F,
 ) -> Result<usize, Error>
 where
     F: FnMut(PacketRef<'_>) -> Result<(), Error>,
 {
-    use pcap_parser::PcapError as PcapParserError;
-
     let mut count = 0;
     while count < max {
         match reader.next() {
             Ok((offset, block)) => {
                 match block {
-                    PcapBlockOwned::NG(ng_block) => {
-                        use pcap_parser::pcapng::*;
-
-                        match ng_block {
-                            Block::InterfaceDescription(idb) => {
-                                *link_type = idb.linktype.0 as u32;
-                                reader.consume(offset);
-                                continue;
-                            }
-                            Block::EnhancedPacket(epb) => {
-                                *frame_number += 1;
-
-                                let timestamp_us =
-                                    ((epb.ts_high as i64) << 32) | (epb.ts_low as i64);
-
-                                // Create borrowed packet reference - no copy!
-                                let packet_ref = PacketRef {
-                                    frame_number: *frame_number,
-                                    timestamp_us,
-                                    captured_len: epb.caplen,
-                                    original_len: epb.origlen,
-                                    link_type: *link_type as u16,
-                                    data: epb.data, // Borrowed from pcap_parser buffer
-                                };
-
-                                // Call the callback with borrowed data
-                                f(packet_ref)?;
-
-                                // Only consume after callback completes
-                                reader.consume(offset);
-                                count += 1;
-                            }
-                            Block::SimplePacket(spb) => {
-                                *frame_number += 1;
-
-                                // Create borrowed packet reference - no copy!
-                                let packet_ref = PacketRef {
-                                    frame_number: *frame_number,
-                                    timestamp_us: 0,
-                                    captured_len: spb.data.len() as u32,
-                                    original_len: spb.origlen,
-                                    link_type: *link_type as u16,
-                                    data: spb.data, // Borrowed from pcap_parser buffer
-                                };
-
-                                // Call the callback with borrowed data
-                                f(packet_ref)?;
-
-                                // Only consume after callback completes
-                                reader.consume(offset);
-                                count += 1;
-                            }
-                            _ => {
-                                reader.consume(offset);
-                                continue;
-                            }
+                    PcapBlockOwned::NG(ng_block) => match ng_block {
+                        Block::SectionHeader(_) => {
+                            // New section: interface namespace resets.
+                            interfaces.clear();
+                            reader.consume(offset);
                         }
-                    }
+                        Block::InterfaceDescription(idb) => {
+                            let info = InterfaceInfo {
+                                link_type: idb.linktype.0 as u32,
+                                if_tsresol: idb.if_tsresol,
+                                snaplen: idb.snaplen,
+                            };
+                            *link_type = info.link_type;
+                            interfaces.push(info);
+                            reader.consume(offset);
+                        }
+                        Block::EnhancedPacket(epb) => {
+                            *frame_number += 1;
+                            let (lt, resolution) = interfaces
+                                .get(epb.if_id as usize)
+                                .map(|i| (i.link_type, i.resolution()))
+                                .unwrap_or((*link_type, DEFAULT_RESOLUTION));
+                            let timestamp_ns = ns_from_ticks(epb.ts_high, epb.ts_low, resolution);
+                            // `packet_data()` strips the on-disk 32-bit padding.
+                            let data = epb.packet_data();
+                            let packet_ref = PacketRef {
+                                frame_number: *frame_number,
+                                timestamp_ns,
+                                captured_len: epb.caplen,
+                                original_len: epb.origlen,
+                                link_type: lt as u16,
+                                data,
+                            };
+                            f(packet_ref)?;
+                            reader.consume(offset);
+                            count += 1;
+                        }
+                        Block::SimplePacket(spb) => {
+                            *frame_number += 1;
+                            let lt = interfaces
+                                .first()
+                                .map(|i| i.link_type)
+                                .unwrap_or(*link_type);
+                            let data = spb.packet_data();
+                            let packet_ref = PacketRef {
+                                frame_number: *frame_number,
+                                timestamp_ns: 0,
+                                captured_len: data.len() as u32,
+                                original_len: spb.origlen,
+                                link_type: lt as u16,
+                                data,
+                            };
+                            f(packet_ref)?;
+                            reader.consume(offset);
+                            count += 1;
+                        }
+                        _ => {
+                            reader.consume(offset);
+                        }
+                    },
                     _ => {
                         reader.consume(offset);
-                        continue;
                     }
                 }
             }
-            Err(PcapParserError::Eof) => break,
+            Err(PcapParserError::Eof) | Err(PcapParserError::UnexpectedEof) => break,
             Err(PcapParserError::Incomplete(_)) => {
                 reader.refill().map_err(|e| {
                     Error::Pcap(PcapError::InvalidFormat {
-                        reason: format!("PCAPNG refill error: {e}"),
+                        reason: format!("PCAPNG refill error: {e:?}"),
                     })
                 })?;
-                continue;
+            }
+            Err(PcapParserError::BufferTooSmall) => {
+                grow_buffer(reader, capacity, "PCAPNG")?;
             }
             Err(e) => {
                 return Err(Error::Pcap(PcapError::InvalidFormat {
-                    reason: format!("PCAPNG parse error: {e}"),
+                    reason: format!("PCAPNG parse error: {e:?}"),
                 }));
             }
         }
@@ -570,29 +560,21 @@ mod tests {
 
     #[test]
     fn test_pcap_format_detect() {
-        // Magic bytes are stored as-written by the capturing system.
-        // On a little-endian machine, 0xa1b2c3d4 is stored as [0xd4, 0xc3, 0xb2, 0xa1].
-        // When read back on a little-endian machine with from_ne_bytes(), we get 0xa1b2c3d4.
-
-        // Little-endian microseconds (stored as [0xd4, 0xc3, 0xb2, 0xa1])
         let le_micro = [0xd4, 0xc3, 0xb2, 0xa1];
         assert_eq!(
             PcapFormat::detect(&le_micro).unwrap(),
             PcapFormat::LegacyLeMicro
         );
 
-        // Big-endian microseconds (stored as [0xa1, 0xb2, 0xc3, 0xd4])
         let be_micro = [0xa1, 0xb2, 0xc3, 0xd4];
         assert_eq!(
             PcapFormat::detect(&be_micro).unwrap(),
             PcapFormat::LegacyBeMicro
         );
 
-        // PCAPNG
         let pcapng = [0x0a, 0x0d, 0x0d, 0x0a];
         assert_eq!(PcapFormat::detect(&pcapng).unwrap(), PcapFormat::PcapNg);
 
-        // Unknown magic
         let unknown = [0xDE, 0xAD, 0xBE, 0xEF];
         assert!(PcapFormat::detect(&unknown).is_err());
     }
@@ -601,110 +583,78 @@ mod tests {
     fn test_pcap_format_properties() {
         assert!(PcapFormat::LegacyLeMicro.is_legacy());
         assert!(!PcapFormat::LegacyLeMicro.is_pcapng());
-
         assert!(PcapFormat::PcapNg.is_pcapng());
-        assert!(!PcapFormat::PcapNg.is_legacy());
+        assert!(PcapFormat::LegacyLeNano.legacy_is_nano());
+        assert!(!PcapFormat::LegacyLeMicro.legacy_is_nano());
+        assert!(PcapFormat::LegacyBeMicro.is_big_endian());
     }
 
     #[test]
-    fn test_pcap_format_endianness() {
-        // Little-endian formats
-        assert!(PcapFormat::LegacyLeMicro.is_little_endian());
-        assert!(PcapFormat::LegacyLeNano.is_little_endian());
-        assert!(PcapFormat::PcapNg.is_little_endian()); // Most PCAPNG files are LE
-
-        // Big-endian formats
-        assert!(!PcapFormat::LegacyBeMicro.is_little_endian());
-        assert!(!PcapFormat::LegacyBeNano.is_little_endian());
+    fn test_ns_conversions() {
+        // micro: 1.5s -> 1_500_000 us -> 1_500_000_000 ns
+        assert_eq!(ns_from_legacy(1, 500_000, false), 1_500_000_000);
+        // nano: 1.5s -> 500_000_000 ns
+        assert_eq!(ns_from_legacy(1, 500_000_000, true), 1_500_000_000);
+        // ticks at microsecond resolution
+        assert_eq!(ns_from_ticks(0, 1_500_000, 1_000_000), 1_500_000_000);
+        // ticks at nanosecond resolution
+        assert_eq!(
+            ns_from_ticks(0, 1_500_000_000, 1_000_000_000),
+            1_500_000_000
+        );
     }
 
-    /// Create a minimal valid PCAP file for testing.
+    /// Create a minimal valid legacy PCAP (LE micro) with one packet.
     fn create_minimal_pcap() -> Vec<u8> {
         let mut data = Vec::new();
-
-        // PCAP global header
-        data.extend_from_slice(&[0xd4, 0xc3, 0xb2, 0xa1]); // Magic (little endian)
-        data.extend_from_slice(&[0x02, 0x00]); // Version major (2)
-        data.extend_from_slice(&[0x04, 0x00]); // Version minor (4)
+        data.extend_from_slice(&[0xd4, 0xc3, 0xb2, 0xa1]); // Magic (LE micro)
+        data.extend_from_slice(&[0x02, 0x00]); // Version major
+        data.extend_from_slice(&[0x04, 0x00]); // Version minor
         data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // Thiszone
         data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // Sigfigs
-        data.extend_from_slice(&[0xff, 0xff, 0x00, 0x00]); // Snaplen (65535)
+        data.extend_from_slice(&[0xff, 0xff, 0x00, 0x00]); // Snaplen
         data.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]); // Network (Ethernet)
 
-        // One packet header + minimal Ethernet frame
         let packet_data = [
-            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // Dst MAC
-            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, // Src MAC
-            0x08, 0x00, // EtherType (IPv4)
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x08, 0x00,
         ];
-
-        let ts_sec: u32 = 1000000000;
-        let ts_usec: u32 = 500000;
-        let caplen: u32 = packet_data.len() as u32;
-        let origlen: u32 = packet_data.len() as u32;
-
+        let ts_sec: u32 = 1_000_000_000;
+        let ts_usec: u32 = 500_000;
         data.extend_from_slice(&ts_sec.to_le_bytes());
         data.extend_from_slice(&ts_usec.to_le_bytes());
-        data.extend_from_slice(&caplen.to_le_bytes());
-        data.extend_from_slice(&origlen.to_le_bytes());
+        data.extend_from_slice(&(packet_data.len() as u32).to_le_bytes());
+        data.extend_from_slice(&(packet_data.len() as u32).to_le_bytes());
         data.extend_from_slice(&packet_data);
-
         data
     }
 
     #[test]
     fn test_generic_reader_from_memory() {
         let pcap_data = create_minimal_pcap();
-
-        // Detect format from magic bytes
-        let format = PcapFormat::detect(&pcap_data).expect("Failed to detect format");
-
+        let format = PcapFormat::detect(&pcap_data).expect("detect");
         let cursor = Cursor::new(pcap_data);
-        let mut reader =
-            GenericPcapReader::with_format(cursor, format).expect("Failed to create reader");
+        let mut reader = GenericPcapReader::with_format(cursor, format).expect("reader");
 
-        // Read first packet
-        let packet = reader.next_packet().expect("Read error");
-        assert!(packet.is_some());
-
-        let pkt = packet.unwrap();
-        assert_eq!(pkt.frame_number, 1);
-        assert_eq!(pkt.captured_length, 14);
-        assert_eq!(pkt.original_length, 14);
-        assert_eq!(pkt.link_type, 1); // Ethernet
-        assert_eq!(pkt.timestamp_us, 1000000000_500000i64);
-        assert_eq!(pkt.data.len(), 14);
-
-        // No more packets
-        let packet2 = reader.next_packet().expect("Read error");
-        assert!(packet2.is_none());
+        let packet = reader.next_packet().expect("read").expect("some");
+        assert_eq!(packet.frame_number, 1);
+        assert_eq!(packet.captured_length, 14);
+        assert_eq!(packet.link_type, 1);
+        // 1_000_000_000 s + 500_000 us = 1e18 + 5e11 ns
+        assert_eq!(
+            packet.timestamp_ns,
+            1_000_000_000i64 * 1_000_000_000 + 500_000_000
+        );
+        assert!(reader.next_packet().expect("read").is_none());
     }
 
     #[test]
-    fn test_generic_reader_link_type() {
+    fn test_starting_at_offsets_frame_numbers() {
         let pcap_data = create_minimal_pcap();
-        let format = PcapFormat::detect(&pcap_data).expect("Failed to detect format");
+        let format = PcapFormat::detect(&pcap_data).expect("detect");
         let cursor = Cursor::new(pcap_data);
-
         let mut reader =
-            GenericPcapReader::with_format(cursor, format).expect("Failed to create reader");
-
-        // Link type is set after reading header block
-        reader.next_packet().ok();
-        assert_eq!(reader.link_type(), 1); // Ethernet
-    }
-
-    #[test]
-    fn test_generic_reader_frame_count() {
-        let pcap_data = create_minimal_pcap();
-        let format = PcapFormat::detect(&pcap_data).expect("Failed to detect format");
-        let cursor = Cursor::new(pcap_data);
-
-        let mut reader =
-            GenericPcapReader::with_format(cursor, format).expect("Failed to create reader");
-        assert_eq!(reader.frame_count(), 0);
-
-        reader.next_packet().ok();
-        assert_eq!(reader.frame_count(), 1);
+            GenericPcapReader::with_format_starting_at(cursor, format, 100).expect("reader");
+        let packet = reader.next_packet().expect("read").expect("some");
+        assert_eq!(packet.frame_number, 100);
     }
 }

--- a/pcapsql-core/src/io/source.rs
+++ b/pcapsql-core/src/io/source.rs
@@ -26,8 +26,8 @@ use crate::pcap::PcapReader;
 pub struct PacketRef<'a> {
     /// Frame number (1-indexed, matching Wireshark)
     pub frame_number: u64,
-    /// Timestamp in microseconds since Unix epoch
-    pub timestamp_us: i64,
+    /// Timestamp in nanoseconds since Unix epoch
+    pub timestamp_ns: i64,
     /// Captured length (may be less than original)
     pub captured_len: u32,
     /// Original packet length on the wire
@@ -111,8 +111,8 @@ pub struct PacketSourceMetadata {
 pub struct RawPacket {
     /// Frame number (1-indexed)
     pub frame_number: u64,
-    /// Timestamp in microseconds since Unix epoch
-    pub timestamp_us: i64,
+    /// Timestamp in nanoseconds since Unix epoch
+    pub timestamp_ns: i64,
     /// Captured length (may be less than original)
     pub captured_length: u32,
     /// Original packet length on the wire
@@ -127,7 +127,7 @@ impl RawPacket {
     /// Create a new raw packet from owned data.
     pub fn new(
         frame_number: u64,
-        timestamp_us: i64,
+        timestamp_ns: i64,
         captured_length: u32,
         original_length: u32,
         link_type: u16,
@@ -135,7 +135,7 @@ impl RawPacket {
     ) -> Self {
         Self {
             frame_number,
-            timestamp_us,
+            timestamp_ns,
             captured_length,
             original_length,
             link_type,
@@ -146,7 +146,7 @@ impl RawPacket {
     /// Create a new raw packet from Bytes (zero-copy if already Bytes).
     pub fn from_bytes(
         frame_number: u64,
-        timestamp_us: i64,
+        timestamp_ns: i64,
         captured_length: u32,
         original_length: u32,
         link_type: u16,
@@ -154,7 +154,7 @@ impl RawPacket {
     ) -> Self {
         Self {
             frame_number,
-            timestamp_us,
+            timestamp_ns,
             captured_length,
             original_length,
             link_type,

--- a/pcapsql-core/tests/reader_groundtruth.rs
+++ b/pcapsql-core/tests/reader_groundtruth.rs
@@ -1,0 +1,285 @@
+//! Sequential ground-truth tests for the PCAP/PCAPNG reader.
+//!
+//! Every capture produced by `pcapsql-testgen` carries its expected frames
+//! (numbers, nanosecond timestamps, lengths, link types, payload bytes). These
+//! tests assert that a sequential read through the source layer reproduces that
+//! ground truth exactly — across all four legacy magic variants, PCAPNG with
+//! single/multiple interfaces (differing `if_tsresol`), multiple sections,
+//! interfaces added midstream, oversized frames (larger than the read buffer),
+//! and truncated captures.
+
+use std::path::{Path, PathBuf};
+
+use pcapsql_core::io::{FilePacketSource, MmapPacketSource, PacketReader, PacketSource};
+use pcapsql_testgen::{
+    generate, jumbo_straddle_capture, legacy_pcap, oversized_frame_capture, pcapng,
+    truncated_capture, CaptureSpec, ExpectedFrame, Format, GenPacket, GeneratedCapture,
+    LegacyVariant, PcapngInterface, PcapngPacket, PcapngSection,
+};
+use tempfile::TempDir;
+
+/// A decoded frame in comparable form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Frame {
+    frame_number: u64,
+    timestamp_ns: i64,
+    caplen: u32,
+    origlen: u32,
+    link_type: u32,
+    data: Vec<u8>,
+}
+
+fn expected_frames(gc: &GeneratedCapture) -> Vec<Frame> {
+    gc.expected
+        .iter()
+        .map(|e: &ExpectedFrame| Frame {
+            frame_number: e.frame_number,
+            timestamp_ns: e.timestamp_ns,
+            caplen: e.caplen,
+            origlen: e.origlen,
+            link_type: e.link_type,
+            data: e.data.clone(),
+        })
+        .collect()
+}
+
+fn drain<R: PacketReader>(reader: &mut R) -> Vec<Frame> {
+    let mut out = Vec::new();
+    loop {
+        let mut batch = Vec::new();
+        let n = reader
+            .process_packets(64, |p| {
+                batch.push(Frame {
+                    frame_number: p.frame_number,
+                    timestamp_ns: p.timestamp_ns,
+                    caplen: p.captured_len,
+                    origlen: p.original_len,
+                    link_type: p.link_type as u32,
+                    data: p.data.to_vec(),
+                });
+                Ok(())
+            })
+            .expect("process_packets");
+        out.extend(batch);
+        if n == 0 {
+            break;
+        }
+    }
+    out
+}
+
+fn write_capture(dir: &Path, name: &str, bytes: &[u8]) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, bytes).expect("write capture");
+    path
+}
+
+fn read_sequential_mmap(path: &Path) -> Vec<Frame> {
+    let source = MmapPacketSource::open(path).expect("open mmap");
+    let mut r = source.reader(None).expect("mmap reader");
+    drain(&mut r)
+}
+
+fn read_sequential_file(path: &Path) -> Vec<Frame> {
+    let source = FilePacketSource::open(path).expect("open file");
+    let mut r = source.reader(None).expect("file reader");
+    drain(&mut r)
+}
+
+/// Core assertion: a sequential read (mmap and file backends) equals the
+/// generator's ground truth, frame for frame.
+fn assert_equivalent(gc: &GeneratedCapture) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_capture(dir.path(), "cap", &gc.bytes);
+    let expected = expected_frames(gc);
+
+    let mm = read_sequential_mmap(&path);
+    assert_eq!(mm, expected, "sequential mmap read must equal ground truth");
+
+    let fi = read_sequential_file(&path);
+    assert_eq!(fi, expected, "sequential file read must equal ground truth");
+}
+
+// ----------------------------------------------------------------------------
+// Explicit edge-case tests
+// ----------------------------------------------------------------------------
+
+#[test]
+fn legacy_all_four_variants() {
+    for variant in [
+        LegacyVariant::LeMicro,
+        LegacyVariant::BeMicro,
+        LegacyVariant::LeNano,
+        LegacyVariant::BeNano,
+    ] {
+        let packets: Vec<GenPacket> = (0..20)
+            .map(|i| GenPacket {
+                ts_sec: 1_700_000_000 + i,
+                ts_frac: (i * 12345) % 1_000_000_000,
+                data: vec![(i % 256) as u8; 14 + (i as usize % 50)],
+                origlen: 14 + (i % 50),
+            })
+            .collect();
+        let gc = legacy_pcap(variant, 1, 65535, &packets);
+        assert_equivalent(&gc);
+    }
+}
+
+#[test]
+fn pcapng_single_interface() {
+    let gc = pcapng(&[PcapngSection {
+        interfaces: vec![PcapngInterface {
+            link_type: 1,
+            tsresol: 6,
+            snaplen: 65535,
+        }],
+        packets: (0..25)
+            .map(|i| PcapngPacket {
+                interface_id: 0,
+                ts_sec: 1_700_000_000 + i,
+                ts_frac_units: (i * 7) % 1_000_000,
+                data: vec![(i % 256) as u8; 20],
+                origlen: 20,
+            })
+            .collect(),
+    }]);
+    assert_equivalent(&gc);
+}
+
+#[test]
+fn pcapng_multi_interface_differing_tsresol() {
+    // Interface 0 microsecond, interface 1 nanosecond. Both must decode to the
+    // correct nanosecond wall-clock.
+    let gc = pcapng(&[PcapngSection {
+        interfaces: vec![
+            PcapngInterface {
+                link_type: 1,
+                tsresol: 6,
+                snaplen: 65535,
+            },
+            PcapngInterface {
+                link_type: 1,
+                tsresol: 9,
+                snaplen: 262144,
+            },
+        ],
+        packets: (0..40)
+            .map(|i| PcapngPacket {
+                interface_id: (i % 2) as u32,
+                ts_sec: 1_700_000_000 + i,
+                // ts_frac_units is in the interface's own units.
+                ts_frac_units: if i % 2 == 0 {
+                    (i * 11) % 1_000_000
+                } else {
+                    (i * 13) % 1_000_000_000
+                },
+                data: vec![(i % 256) as u8; 30],
+                origlen: 30,
+            })
+            .collect(),
+    }]);
+    assert_equivalent(&gc);
+}
+
+#[test]
+fn pcapng_multi_section() {
+    let mk_section = |tsresol: u8, base: u64| PcapngSection {
+        interfaces: vec![PcapngInterface {
+            link_type: 1,
+            tsresol,
+            snaplen: 65535,
+        }],
+        packets: (0..15)
+            .map(|i| PcapngPacket {
+                interface_id: 0,
+                ts_sec: base + i,
+                ts_frac_units: i % 1_000,
+                data: vec![(i % 256) as u8; 18],
+                origlen: 18,
+            })
+            .collect(),
+    };
+    let gc = pcapng(&[
+        mk_section(6, 1_700_000_000),
+        mk_section(9, 1_700_001_000),
+        mk_section(3, 1_700_002_000),
+    ]);
+    assert_equivalent(&gc);
+}
+
+#[test]
+fn pcapng_interface_added_midstream() {
+    let spec = CaptureSpec {
+        format: Format::Pcapng,
+        seed: 99,
+        packet_count: 40,
+        min_size: 16,
+        max_size: 80,
+        link_type: 1,
+        interfaces: vec![6],
+        sections: 1,
+        add_interface_midstream: true,
+    };
+    let gc = generate(&spec);
+    assert_equivalent(&gc);
+}
+
+#[test]
+fn oversized_frame_exceeds_read_buffer() {
+    // A single frame larger than the 256 KiB read buffer exercises the grow path.
+    let gc = oversized_frame_capture(300_000);
+    assert_equivalent(&gc);
+}
+
+#[test]
+fn jumbo_frames_among_normal_frames() {
+    let gc = jumbo_straddle_capture(7, 280_000, 30);
+    assert_equivalent(&gc);
+}
+
+#[test]
+fn truncated_capture_reads_complete_prefix() {
+    // Declared length exceeds bytes present: the reader must stop gracefully
+    // after the complete frames, matching the ground-truth prefix.
+    let gc = truncated_capture(123);
+    let dir = TempDir::new().unwrap();
+    let path = write_capture(dir.path(), "trunc.pcap", &gc.bytes);
+    let expected = expected_frames(&gc);
+    assert_eq!(read_sequential_mmap(&path), expected);
+    assert_eq!(read_sequential_file(&path), expected);
+}
+
+/// Deterministic sweep of the generator's edge-case space (seeds × formats ×
+/// interface configurations), all checked against ground truth.
+#[test]
+fn generated_capture_sweep() {
+    let formats = [
+        Format::LegacyLeMicro,
+        Format::LegacyBeMicro,
+        Format::LegacyLeNano,
+        Format::LegacyBeNano,
+        Format::Pcapng,
+    ];
+    for seed in [1u64, 42, 0xDEAD_BEEF] {
+        for format in formats {
+            for (interfaces, sections, midstream) in [
+                (vec![6u8], 1usize, false),
+                (vec![6, 9], 1, false),
+                (vec![9], 2, true),
+            ] {
+                let spec = CaptureSpec {
+                    format,
+                    seed,
+                    packet_count: 30,
+                    min_size: 14,
+                    max_size: 120,
+                    link_type: 1,
+                    interfaces,
+                    sections,
+                    add_interface_midstream: midstream,
+                };
+                assert_equivalent(&generate(&spec));
+            }
+        }
+    }
+}

--- a/pcapsql-datafusion/src/query/builders/normalized.rs
+++ b/pcapsql-datafusion/src/query/builders/normalized.rs
@@ -125,7 +125,7 @@ impl NormalizedBatchSet {
         // Always add to frames table
         self.frames_builder.add_frame_from_raw(
             packet.frame_number,
-            packet.timestamp_us,
+            packet.timestamp_ns,
             packet.captured_len,
             packet.original_len,
             packet.data,
@@ -230,7 +230,7 @@ mod tests {
     fn create_test_packet(frame_number: u64) -> RawPacket {
         RawPacket {
             frame_number,
-            timestamp_us: 1000000 * frame_number as i64,
+            timestamp_ns: 1_000_000_000 * frame_number as i64,
             captured_length: 100,
             original_length: 100,
             link_type: 1,

--- a/pcapsql-datafusion/src/query/builders/protocol.rs
+++ b/pcapsql-datafusion/src/query/builders/protocol.rs
@@ -453,7 +453,8 @@ impl ProtocolBatchBuilder {
             let builder = &mut self.builders[*idx];
             match field_name.as_str() {
                 "frame_number" => builder.append_u64(raw.frame_number),
-                "timestamp" => builder.append_timestamp(raw.timestamp_us),
+                // Arrow timestamp column is microseconds; reader timestamps are ns.
+                "timestamp" => builder.append_timestamp(raw.timestamp_ns / 1_000),
                 "length" => {
                     if let DynamicBuilder::UInt32(b) = builder {
                         b.append_value(raw.captured_length);
@@ -482,7 +483,7 @@ impl ProtocolBatchBuilder {
     pub fn add_frame_from_raw(
         &mut self,
         frame_number: u64,
-        timestamp_us: i64,
+        timestamp_ns: i64,
         captured_len: u32,
         original_len: u32,
         data: &[u8],
@@ -498,7 +499,8 @@ impl ProtocolBatchBuilder {
             let builder = &mut self.builders[*idx];
             match field_name.as_str() {
                 "frame_number" => builder.append_u64(frame_number),
-                "timestamp" => builder.append_timestamp(timestamp_us),
+                // Arrow timestamp column is microseconds; reader timestamps are ns.
+                "timestamp" => builder.append_timestamp(timestamp_ns / 1_000),
                 "length" => {
                     if let DynamicBuilder::UInt32(b) = builder {
                         b.append_value(captured_len);
@@ -681,7 +683,7 @@ mod tests {
 
         let raw = RawPacket {
             frame_number: 1,
-            timestamp_us: 1000000,
+            timestamp_ns: 1_000_000_000,
             captured_length: 100,
             original_length: 100,
             link_type: 1,

--- a/pcapsql-datafusion/src/query/frames.rs
+++ b/pcapsql-datafusion/src/query/frames.rs
@@ -48,7 +48,8 @@ impl FramesBatchBuilder {
         self.rows += 1;
 
         self.frame_numbers.append_value(raw.frame_number);
-        self.timestamps.append_value(raw.timestamp_us);
+        // Arrow timestamp column is microseconds; reader timestamps are ns.
+        self.timestamps.append_value(raw.timestamp_ns / 1_000);
         self.lengths.append_value(raw.captured_length);
         self.original_lengths.append_value(raw.original_length);
         self.link_types.append_value(raw.link_type);
@@ -121,7 +122,7 @@ mod tests {
     fn create_test_raw_packet(frame_number: u64, data: Vec<u8>) -> RawPacket {
         RawPacket {
             frame_number,
-            timestamp_us: 1000000 * frame_number as i64,
+            timestamp_ns: 1_000_000_000 * frame_number as i64,
             captured_length: data.len() as u32,
             original_length: data.len() as u32,
             link_type: 1, // Ethernet

--- a/pcapsql-datafusion/src/query/mod.rs
+++ b/pcapsql-datafusion/src/query/mod.rs
@@ -328,7 +328,7 @@ impl QueryEngine {
             let mut reader = source.reader(None)?;
             let mut first_ts = 0i64;
             reader.process_packets(1, |packet| {
-                first_ts = packet.timestamp_us;
+                first_ts = packet.timestamp_ns / 1_000;
                 Ok(())
             })?;
             first_ts
@@ -345,7 +345,7 @@ impl QueryEngine {
             loop {
                 let count = reader
                     .process_packets(1000, |packet| {
-                        last_ts = packet.timestamp_us;
+                        last_ts = packet.timestamp_ns / 1_000;
                         Ok(())
                     })
                     .unwrap_or(0);

--- a/pcapsql-datafusion/src/query/providers/batch_stream.rs
+++ b/pcapsql-datafusion/src/query/providers/batch_stream.rs
@@ -214,7 +214,7 @@ impl<R: PacketReader> ProtocolBatchStream<R> {
                     if table_name == "frames" {
                         builder.add_frame_from_raw(
                             packet.frame_number,
-                            packet.timestamp_us,
+                            packet.timestamp_ns,
                             packet.captured_len,
                             packet.original_len,
                             packet.data, // Borrowed slice - copied into Arrow buffer

--- a/pcapsql-datafusion/src/query/stream_tables.rs
+++ b/pcapsql-datafusion/src/query/stream_tables.rs
@@ -61,7 +61,12 @@ impl StreamTableBuilder {
         // and feed it to the stream manager
         loop {
             let processed = reader.process_packets(1000, |packet| {
-                self.process_packet(packet.data, packet.frame_number, packet.timestamp_us)?;
+                // process_packet expects microseconds; reader timestamps are ns.
+                self.process_packet(
+                    packet.data,
+                    packet.frame_number,
+                    packet.timestamp_ns / 1_000,
+                )?;
                 Ok(())
             })?;
 

--- a/pcapsql-duckdb/src/vtab/read_pcap.rs
+++ b/pcapsql-duckdb/src/vtab/read_pcap.rs
@@ -217,7 +217,7 @@ impl VTab for ReadPcapVTab {
                     output,
                     row_count,
                     frame_num,
-                    packet.timestamp_us,
+                    packet.timestamp_ns / 1_000,
                     packet.captured_len,
                     packet.original_len,
                     packet.link_type,


### PR DESCRIPTION
## Stage 3/9 — Reader: nanosecond timestamps, per-interface tsresol, robust edges

Reworks `GenericPcapReader` for a trustworthy timestamp axis and resilient handling of awkward input, verified against the Stage 2 generator's ground truth (`reader_groundtruth.rs`).

**Changes**
- Nanosecond timestamps (`timestamp_ns`) end to end, honoring legacy micro/nano magic and PCAPNG per-interface `if_tsresol`; multi-section interface tracking.
- Unified, host-independent format detection by raw magic bytes (no host-order `u32` decode), shared by mmap/file/cloud.
- Oversized-frame `grow()` and graceful truncation handling with a no-progress guard (no more spinning on truncated/oversized input); byte offset via `consumed()`; headerless `with_format_starting_at`.
- DataFusion builders carry nanoseconds and convert to the microsecond Arrow column only at the builder boundary.

**Closes** #79 · **Closes** #80 · **Closes** #81 · **Closes** #82
<sub>(GitHub fires these when the stage lands on `main` after retargeting.)</sub>

---
**Stacked on:** #90 (`claude/stack-02-testgen`) · **Stage:** 3 of 9 · **Epic:** #88 · **Supersedes part of:** #78

Every stage compiles and passes `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` independently.

https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96

---
_Generated by [Claude Code](https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96)_