### PR TITLE
Stage 7/9 — Cloud SeekablePacketSource via byte-range GETs + real object-store tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3541,6 +3541,7 @@ dependencies = [
  "hex",
  "indicatif",
  "nom 7.1.3",
+ "object_store 0.11.2",
  "parquet",
  "pcapsql-core",
  "pcapsql-testgen",

--- a/pcapsql-core/src/io/cloud.rs
+++ b/pcapsql-core/src/io/cloud.rs
@@ -23,8 +23,8 @@
 //! let engine = QueryEngine::with_streaming_source(source).await?;
 //! ```
 
-use std::io::{self, Read};
-use std::sync::Arc;
+use std::io::{self, Chain, Cursor, Read};
+use std::sync::{Arc, Mutex};
 
 use object_store::{path::Path as ObjectPath, ObjectStore};
 use url::Url;
@@ -57,9 +57,12 @@ where
         }
     }
 }
+use super::index::{self, BoundaryIndex};
+use super::source::synth_header_for;
 use crate::io::{
     decompress_header, Compression, DecompressReader, GenericPcapReader, PacketPosition,
-    PacketReader, PacketRef, PacketSource, PacketSourceMetadata, PcapFormat,
+    PacketRange, PacketReader, PacketRef, PacketSource, PacketSourceMetadata, PcapFormat, SeekCost,
+    SeekablePacketSource,
 };
 
 /// Default chunk size for cloud reads (8MB).
@@ -323,6 +326,15 @@ impl ObjectStoreReader {
         })
     }
 
+    /// Open a reader positioned at a byte offset (for mid-file partitions).
+    pub fn open_at(location: &CloudLocation, start: u64) -> Result<Self, Error> {
+        let mut reader = Self::open(location)?;
+        reader.position = start;
+        reader.buffer_start = start;
+        reader.buffer.clear();
+        Ok(reader)
+    }
+
     /// Create a reader with pre-fetched header bytes.
     ///
     /// This is an optimization to avoid re-fetching the header when the
@@ -441,6 +453,10 @@ pub struct CloudPacketSource {
     metadata: PacketSourceMetadata,
     compression: Compression,
     pcap_format: PcapFormat,
+    /// Lazily built boundary index (uncompressed objects only).
+    index: Arc<Mutex<Option<Arc<BoundaryIndex>>>>,
+    index_stride: u64,
+    header_hash: u64,
 }
 
 impl CloudPacketSource {
@@ -542,15 +558,54 @@ impl CloudPacketSource {
             link_type,
             snaplen: 65535,
             size_bytes: Some(object_size),
-            packet_count: None, // Would require scanning
+            packet_count: None, // Filled by the index if built
         };
+
+        let header_hash = index::header_hash(&header_bytes);
 
         Ok(Self {
             location,
             metadata,
             compression,
             pcap_format,
+            index: Arc::new(Mutex::new(None)),
+            index_stride: index::DEFAULT_CHECKPOINT_STRIDE,
+            header_hash,
         })
+    }
+
+    /// Set the checkpoint stride for index building (smaller = finer partitions).
+    pub fn with_index_stride(mut self, stride: u64) -> Self {
+        self.index_stride = stride.max(1);
+        self
+    }
+
+    /// Build (and memoize) the boundary index by scanning the uncompressed
+    /// object. This is the one full read; subsequent partition reads use exact
+    /// offsets from the index (no byte-range re-sync).
+    fn ensure_index(&self) -> Result<Arc<BoundaryIndex>, Error> {
+        if self.compression.is_compressed() {
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "compressed cloud objects are not seekable; cannot build boundary index",
+            )));
+        }
+        let mut guard = self.index.lock().expect("index mutex poisoned");
+        if let Some(idx) = guard.as_ref() {
+            return Ok(idx.clone());
+        }
+        let reader = ObjectStoreReader::open(&self.location)?;
+        let idx = index::build_boundary_index(
+            reader,
+            self.pcap_format,
+            self.index_stride,
+            self.metadata.size_bytes.unwrap_or(0),
+            None,
+            self.header_hash,
+        )?;
+        let idx = Arc::new(idx);
+        *guard = Some(idx.clone());
+        Ok(idx)
     }
 
     /// Parse link type from decompressed PCAP header bytes.
@@ -714,60 +769,122 @@ impl PacketSource for CloudPacketSource {
     }
 
     fn sequential_reader(&self) -> Result<Self::Reader, Error> {
-        CloudPacketReader::new(
-            &self.location,
-            self.compression,
-            self.pcap_format,
-            self.metadata.link_type,
-        )
+        CloudPacketReader::sequential(&self.location, self.compression, self.pcap_format)
     }
 }
 
+impl SeekablePacketSource for CloudPacketSource {
+    fn seek_cost(&self) -> SeekCost {
+        SeekCost::RangeRequest
+    }
+
+    fn reader_at(&self, range: &PacketRange) -> Result<Self::Reader, Error> {
+        if self.compression.is_compressed() {
+            return self.sequential_reader();
+        }
+        let idx = self.ensure_index()?;
+        let header = synth_header_for(&idx, range.start.frame_number, self.pcap_format)?;
+        let end_frame = range.end.as_ref().map(|e| e.frame_number);
+        CloudPacketReader::at(
+            &self.location,
+            self.pcap_format,
+            header,
+            range.start.byte_offset,
+            range.start.frame_number,
+            end_frame,
+        )
+    }
+
+    fn partitions(&self, max: usize) -> Result<Vec<PacketRange>, Error> {
+        if self.compression.is_compressed() {
+            return Ok(vec![PacketRange::whole()]);
+        }
+        let idx = self.ensure_index()?;
+        Ok(idx.partition_ranges(max))
+    }
+}
+
+/// The concrete `Read` stack for cloud readers: an optional synthesized header
+/// (empty for sequential reads) chained before the object-store range reader,
+/// wrapped in decompression.
+type CloudInner = GenericPcapReader<DecompressReader<Chain<Cursor<Vec<u8>>, ObjectStoreReader>>>;
+
 /// Cloud-backed packet reader.
-///
-/// Wraps the ObjectStoreReader → DecompressReader → GenericPcapReader stack
-/// and implements [`PacketReader`] for the query engine.
 pub struct CloudPacketReader {
-    inner: GenericPcapReader<DecompressReader<ObjectStoreReader>>,
+    inner: CloudInner,
     link_type: u32,
-    position: PacketPosition,
+    end_frame: Option<u64>,
 }
 
 impl CloudPacketReader {
-    /// Create a new cloud packet reader.
-    fn new(
+    /// Sequential reader over the whole object (honors compression).
+    fn sequential(
         location: &CloudLocation,
         compression: Compression,
         format: PcapFormat,
-        link_type: u32,
     ) -> Result<Self, Error> {
         let cloud_reader = ObjectStoreReader::open(location)?;
-        let decompress = DecompressReader::new(cloud_reader, compression)?;
+        let chain = Cursor::new(Vec::new()).chain(cloud_reader);
+        let decompress = DecompressReader::new(chain, compression)?;
         let inner = GenericPcapReader::with_format(decompress, format)?;
-
+        let link_type = inner.link_type();
         Ok(Self {
             inner,
             link_type,
-            position: PacketPosition::START,
+            end_frame: None,
+        })
+    }
+
+    /// Reader at a byte offset, prepending a synthesized header. Uncompressed
+    /// objects only (the only ones that are partitioned).
+    fn at(
+        location: &CloudLocation,
+        format: PcapFormat,
+        synth_header: Vec<u8>,
+        byte_offset: u64,
+        start_frame: u64,
+        end_frame: Option<u64>,
+    ) -> Result<Self, Error> {
+        let cloud_reader = ObjectStoreReader::open_at(location, byte_offset)?;
+        let chain = Cursor::new(synth_header).chain(cloud_reader);
+        let decompress = DecompressReader::new(chain, Compression::None)?;
+        let inner = GenericPcapReader::with_format_starting_at(decompress, format, start_frame)?;
+        let link_type = inner.link_type();
+        Ok(Self {
+            inner,
+            link_type,
+            end_frame,
         })
     }
 }
 
 impl PacketReader for CloudPacketReader {
-    fn process_packets<F>(&mut self, max: usize, mut f: F) -> Result<usize, Error>
+    fn process_packets<F>(&mut self, max: usize, f: F) -> Result<usize, Error>
     where
         F: FnMut(PacketRef<'_>) -> Result<(), Error>,
     {
-        let count = self.inner.process_packets(max, |packet| {
-            self.position.frame_number = packet.frame_number + 1;
-            f(packet)
-        })?;
-
+        // `end_frame` is exclusive: emit frames with number < end_frame.
+        let effective_max = match self.end_frame {
+            Some(end) => {
+                let current = self.inner.frame_count();
+                let remaining = end.saturating_sub(current).saturating_sub(1);
+                if remaining == 0 {
+                    return Ok(0);
+                }
+                max.min(remaining as usize)
+            }
+            None => max,
+        };
+        let count = self.inner.process_packets(effective_max, f)?;
+        self.link_type = self.inner.link_type();
         Ok(count)
     }
 
     fn position(&self) -> PacketPosition {
-        self.position.clone()
+        PacketPosition {
+            byte_offset: self.inner.consumed_bytes(),
+            frame_number: self.inner.frame_count(),
+        }
     }
 
     fn link_type(&self) -> u32 {

--- a/pcapsql-datafusion/Cargo.toml
+++ b/pcapsql-datafusion/Cargo.toml
@@ -89,6 +89,7 @@ compact_str.workspace = true
 # Cloud storage for integration tests
 pcapsql-core = { path = "../pcapsql-core", features = ["s3"] }
 pcapsql-testgen.workspace = true
+object_store.workspace = true
 
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/pcapsql-datafusion/tests/cloud_integration.rs
+++ b/pcapsql-datafusion/tests/cloud_integration.rs
@@ -1,0 +1,173 @@
+//! Integration tests against a real S3-compatible object store (MinIO/SeaweedFS).
+//!
+//! Gated two ways so the normal `cargo test` run needs no object store:
+//!   1. the `s3` cargo feature, and
+//!   2. the `PCAPSQL_S3_TEST_ENDPOINT` environment variable.
+//!
+//! To run against a local store (see `testdata/cloud/`):
+//! ```text
+//! docker compose -f testdata/cloud/docker-compose.yml up -d   # MinIO
+//! # or run SeaweedFS:  weed server -s3 -s3.config=testdata/cloud/s3.json
+//! AWS_ACCESS_KEY_ID=pcapsqlkey AWS_SECRET_ACCESS_KEY=pcapsqlsecret \
+//! AWS_REGION=us-east-1 PCAPSQL_S3_TEST_ENDPOINT=http://127.0.0.1:8333 \
+//!   cargo test -p pcapsql-datafusion --features s3 --test cloud_integration -- --nocapture
+//! ```
+//!
+//! The key property mirrors the local sources: parsing a cloud object at N
+//! partitions (independent byte-range GETs) yields exactly the same rows in the
+//! same order as parsing it at 1 partition.
+#![cfg(feature = "s3")]
+
+use object_store::{ObjectStore, PutPayload};
+use pcapsql_core::io::{
+    CloudLocation, CloudPacketSource, PacketReader, PacketSource, SeekablePacketSource,
+};
+use pcapsql_testgen::{legacy_pcap, GenPacket, LegacyVariant};
+
+/// Endpoint of the test object store, or `None` to skip (store unavailable).
+fn endpoint() -> Option<String> {
+    std::env::var("PCAPSQL_S3_TEST_ENDPOINT")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+fn bucket() -> String {
+    std::env::var("PCAPSQL_S3_TEST_BUCKET").unwrap_or_else(|_| "test-pcaps".to_string())
+}
+
+fn location(ep: &str, key: &str) -> CloudLocation {
+    CloudLocation::parse(&format!("s3://{}/{}", bucket(), key))
+        .expect("parse s3 url")
+        .with_endpoint(ep)
+}
+
+/// Upload bytes through the same object_store backend the source reads through.
+async fn upload(ep: &str, key: &str, bytes: Vec<u8>) {
+    let loc = location(ep, key);
+    let store = loc.build_store().expect("build store");
+    store
+        .put(&loc.object_path(), PutPayload::from(bytes))
+        .await
+        .expect("put object");
+}
+
+/// A real Ethernet/IPv4/UDP frame so protocol tables populate.
+fn udp_packet(src_port: u16, payload_len: usize) -> Vec<u8> {
+    let mut p = Vec::with_capacity(42 + payload_len);
+    p.extend_from_slice(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+    p.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
+    p.extend_from_slice(&[0x08, 0x00]);
+    let ip_total = (20 + 8 + payload_len) as u16;
+    p.push(0x45);
+    p.push(0x00);
+    p.extend_from_slice(&ip_total.to_be_bytes());
+    p.extend_from_slice(&[0x00, 0x00, 0x40, 0x00]);
+    p.push(64);
+    p.push(17);
+    p.extend_from_slice(&[0x00, 0x00]);
+    p.extend_from_slice(&[192, 168, 0, 1]);
+    p.extend_from_slice(&[192, 168, 0, 2]);
+    let udp_len = (8 + payload_len) as u16;
+    p.extend_from_slice(&src_port.to_be_bytes());
+    p.extend_from_slice(&53u16.to_be_bytes());
+    p.extend_from_slice(&udp_len.to_be_bytes());
+    p.extend_from_slice(&[0x00, 0x00]);
+    p.extend(std::iter::repeat_n(0xAB, payload_len));
+    p
+}
+
+/// Generate a capture > 16 MiB so the RangeRequest cost gate allows partitioning.
+fn big_capture(count: usize, payload: usize) -> Vec<u8> {
+    let packets: Vec<GenPacket> = (0..count)
+        .map(|i| {
+            let data = udp_packet(10_000 + (i % 5000) as u16, payload);
+            let origlen = data.len() as u32;
+            GenPacket {
+                ts_sec: 1_700_000_000 + (i / 1000) as u32,
+                ts_frac: (i as u32 * 251) % 1_000_000,
+                data,
+                origlen,
+            }
+        })
+        .collect();
+    legacy_pcap(LegacyVariant::LeMicro, 1, 65535, &packets).bytes
+}
+
+fn drain<R: PacketReader>(reader: &mut R) -> Vec<u64> {
+    let mut out = Vec::new();
+    loop {
+        let mut batch = Vec::new();
+        let n = reader
+            .process_packets(256, |p| {
+                batch.push(p.frame_number);
+                Ok(())
+            })
+            .expect("process_packets");
+        out.extend(batch);
+        if n == 0 {
+            break;
+        }
+    }
+    out
+}
+
+/// Source-level: byte-range partitioned reads over the network reproduce the
+/// sequential read exactly.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn s3_partition_equivalence_source_level() {
+    let Some(ep) = endpoint() else {
+        eprintln!("skipping cloud test: PCAPSQL_S3_TEST_ENDPOINT not set");
+        return;
+    };
+
+    let key = "equiv/source_level.pcap";
+    let total = 20_000u64;
+    upload(&ep, key, big_capture(total as usize, 1000)).await;
+
+    let source = CloudPacketSource::open(location(&ep, key))
+        .expect("open cloud source")
+        .with_index_stride(2048);
+
+    assert!(
+        source.metadata().size_bytes.unwrap() > 16 * 1024 * 1024,
+        "object must be large enough to be worth partitioning"
+    );
+
+    // Sequential read over the network.
+    let mut seq_reader = source.sequential_reader().expect("sequential reader");
+    let seq = drain(&mut seq_reader);
+    assert_eq!(seq, (1..=total).collect::<Vec<_>>());
+
+    // Partitioned: independent byte-range GETs, reassembled in order.
+    let ranges = source.partitions(4).expect("partitions");
+    assert!(
+        ranges.len() > 1,
+        "a >16MiB object should split into multiple partitions, got {}",
+        ranges.len()
+    );
+    let mut part = Vec::new();
+    for range in &ranges {
+        let mut r = source.reader_at(range).expect("reader_at over network");
+        part.extend(drain(&mut r));
+    }
+    assert_eq!(
+        part, seq,
+        "partitioned (range-GET) read must equal sequential"
+    );
+}
+
+/// A small object still reads correctly sequentially.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn s3_small_object_sequential() {
+    let Some(ep) = endpoint() else {
+        eprintln!("skipping cloud test: PCAPSQL_S3_TEST_ENDPOINT not set");
+        return;
+    };
+
+    let key = "small/tiny.pcap";
+    upload(&ep, key, big_capture(50, 20)).await;
+
+    let source = CloudPacketSource::open(location(&ep, key)).expect("open");
+    let mut r = source.sequential_reader().expect("reader");
+    assert_eq!(drain(&mut r).len(), 50);
+}

--- a/testdata/cloud/docker-compose.yml
+++ b/testdata/cloud/docker-compose.yml
@@ -1,29 +1,44 @@
-# LocalStack configuration for S3 integration testing
+# Local S3-compatible object store for the cloud integration tests.
+#
+# Brings up MinIO (Chainguard image, no Docker Hub rate limit) and creates the
+# `test-pcaps` bucket. The tests upload their own fixtures, so only the bucket is
+# needed here.
 #
 # Usage:
-#   docker compose up -d      # Start LocalStack
-#   ./setup.sh                # Upload test data
-#   docker compose down       # Stop LocalStack
+#   docker compose -f testdata/cloud/docker-compose.yml up -d
+#   AWS_ACCESS_KEY_ID=pcapsqlkey AWS_SECRET_ACCESS_KEY=pcapsqlsecret \
+#   AWS_REGION=us-east-1 PCAPSQL_S3_TEST_ENDPOINT=http://127.0.0.1:9000 \
+#     cargo test -p pcapsql-datafusion --features s3 --test cloud_integration
+#   docker compose -f testdata/cloud/docker-compose.yml down
 #
-# Then run integration tests:
-#   cargo test --features s3 --test cloud_integration -- --ignored
+# If your environment cannot pull container images, see `setup.sh` for a
+# Docker-free SeaweedFS fallback that the tests also run against.
 
 services:
-  localstack:
-    image: localstack/localstack:latest
+  minio:
+    image: cgr.dev/chainguard/minio:latest
+    command: ["server", "/data", "--address", ":9000", "--console-address", ":9001"]
     ports:
-      - "4566:4566"
+      - "9000:9000"
+      - "9001:9001"
     environment:
-      - SERVICES=s3
-      - DEFAULT_REGION=us-east-1
-      - DEBUG=0
-    volumes:
-      - localstack_data:/var/lib/localstack
+      - MINIO_ROOT_USER=pcapsqlkey
+      - MINIO_ROOT_PASSWORD=pcapsqlsecret
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/minio/health/live || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
 
-volumes:
-  localstack_data:
+  # One-shot: create the test bucket, then exit.
+  createbucket:
+    image: cgr.dev/chainguard/minio-client:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 pcapsqlkey pcapsqlsecret &&
+      mc mb --ignore-existing local/test-pcaps &&
+      echo 'bucket test-pcaps ready'
+      "

--- a/testdata/cloud/s3.json
+++ b/testdata/cloud/s3.json
@@ -1,0 +1,11 @@
+{
+  "identities": [
+    {
+      "name": "pcapsql",
+      "credentials": [
+        { "accessKey": "pcapsqlkey", "secretKey": "pcapsqlsecret" }
+      ],
+      "actions": ["Admin", "Read", "Write", "List", "Tagging"]
+    }
+  ]
+}

--- a/testdata/cloud/setup.sh
+++ b/testdata/cloud/setup.sh
@@ -1,89 +1,60 @@
-#!/bin/bash
-# Generate and upload test PCAP files to LocalStack S3 for integration testing.
+#!/usr/bin/env bash
+# Bring up a local S3-compatible object store for the cloud integration tests
+# and create the `test-pcaps` bucket. The tests upload their own fixtures.
 #
-# This script generates ALL test files dynamically - no binary files in git.
+# Two backends are supported:
 #
-# Prerequisites:
-#   - LocalStack running (docker compose up -d)
-#   - AWS CLI installed (or awslocal)
-#   - uvx (for Python dependency management)
-#   - compression tools: gzip, zstd, lz4
+#   MinIO via Docker (preferred, matches CI):
+#       docker compose -f testdata/cloud/docker-compose.yml up -d
+#       export PCAPSQL_S3_TEST_ENDPOINT=http://127.0.0.1:9000
 #
-# Usage:
-#   ./setup.sh
+#   SeaweedFS native binary (Docker-free fallback; used when image registries
+#   are unreachable). This script implements that fallback:
+#       ./testdata/cloud/setup.sh seaweedfs
+#       export PCAPSQL_S3_TEST_ENDPOINT=http://127.0.0.1:8333
+#
+# Then run:
+#   AWS_ACCESS_KEY_ID=pcapsqlkey AWS_SECRET_ACCESS_KEY=pcapsqlsecret \
+#   AWS_REGION=us-east-1 \
+#     cargo test -p pcapsql-datafusion --features s3 --test cloud_integration
+set -euo pipefail
 
-set -e
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUCKET="${PCAPSQL_S3_TEST_BUCKET:-test-pcaps}"
+MODE="${1:-docker}"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ENDPOINT="http://localhost:4566"
-BUCKET="test-pcaps"
-REGION="us-east-1"
-OUTPUT_DIR="/tmp/generated"
+case "$MODE" in
+  docker|minio)
+    echo "Starting MinIO via docker compose..."
+    docker compose -f "$HERE/docker-compose.yml" up -d
+    echo "MinIO up on http://127.0.0.1:9000 (bucket: $BUCKET)"
+    echo "export PCAPSQL_S3_TEST_ENDPOINT=http://127.0.0.1:9000"
+    ;;
 
-# Use awslocal if available, otherwise aws with endpoint override
-if command -v awslocal &> /dev/null; then
-    AWS="awslocal"
-else
-    AWS="aws --endpoint-url=$ENDPOINT --region=$REGION"
-fi
-
-echo "=== Step 1: Generate test PCAP files ==="
-echo "Using uvx to run generator with scapy..."
-
-# Generate all test files
-uvx --with scapy python "$SCRIPT_DIR/../scripts/gen_format_tests.py" --output-dir "$OUTPUT_DIR"
-
-echo ""
-echo "=== Step 2: Wait for LocalStack ==="
-echo "Waiting for LocalStack to be ready..."
-until curl -s "$ENDPOINT/_localstack/health" | grep -q '"s3": *"available"'; do
-    sleep 1
-done
-echo "LocalStack is ready!"
-
-echo ""
-echo "=== Step 3: Create S3 bucket ==="
-$AWS s3 mb "s3://$BUCKET" 2>/dev/null || echo "Bucket already exists"
-
-echo ""
-echo "=== Step 4: Upload generated PCAP files ==="
-for f in "$OUTPUT_DIR"/*.pcap "$OUTPUT_DIR"/*.pcapng; do
-    if [ -f "$f" ]; then
-        echo "Uploading $(basename "$f")..."
-        $AWS s3 cp "$f" "s3://$BUCKET/$(basename "$f")"
+  seaweedfs|weed)
+    # Docker-free fallback using the SeaweedFS binary on PATH (or ./weed).
+    WEED="${WEED_BIN:-weed}"
+    if ! command -v "$WEED" >/dev/null 2>&1 && [ -x "$HERE/weed" ]; then
+      WEED="$HERE/weed"
     fi
-done
+    DATA="$(mktemp -d)"
+    echo "Starting SeaweedFS S3 (data dir: $DATA)..."
+    "$WEED" server -dir="$DATA" -ip=127.0.0.1 -s3 \
+      -s3.config="$HERE/s3.json" -s3.port=8333 >"$DATA/weed.log" 2>&1 &
+    echo $! > "$DATA/weed.pid"
+    # Wait for the S3 endpoint to come up.
+    for _ in $(seq 1 30); do
+      code="$(curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:8333 || true)"
+      [ -n "$code" ] && [ "$code" != "000" ] && break
+      sleep 1
+    done
+    echo "s3.bucket.create -name $BUCKET" | "$WEED" shell >/dev/null 2>&1 || true
+    echo "SeaweedFS up on http://127.0.0.1:8333 (bucket: $BUCKET, pid $(cat "$DATA/weed.pid"))"
+    echo "export PCAPSQL_S3_TEST_ENDPOINT=http://127.0.0.1:8333"
+    ;;
 
-echo ""
-echo "=== Step 5: Create and upload compressed versions ==="
-# Use small_dns.pcap as the base for compression tests
-if [ -f "$OUTPUT_DIR/small_dns.pcap" ]; then
-    echo "Creating gzip compressed version..."
-    gzip -c "$OUTPUT_DIR/small_dns.pcap" > "$OUTPUT_DIR/small_dns.pcap.gz"
-    $AWS s3 cp "$OUTPUT_DIR/small_dns.pcap.gz" "s3://$BUCKET/"
-
-    if command -v zstd &> /dev/null; then
-        echo "Creating zstd compressed version..."
-        zstd -q -c "$OUTPUT_DIR/small_dns.pcap" > "$OUTPUT_DIR/small_dns.pcap.zst"
-        $AWS s3 cp "$OUTPUT_DIR/small_dns.pcap.zst" "s3://$BUCKET/"
-    else
-        echo "Warning: zstd not installed, skipping zstd compression test"
-    fi
-
-    if command -v lz4 &> /dev/null; then
-        echo "Creating lz4 compressed version..."
-        lz4 -q -c "$OUTPUT_DIR/small_dns.pcap" > "$OUTPUT_DIR/small_dns.pcap.lz4"
-        $AWS s3 cp "$OUTPUT_DIR/small_dns.pcap.lz4" "s3://$BUCKET/"
-    else
-        echo "Warning: lz4 not installed, skipping lz4 compression test"
-    fi
-fi
-
-echo ""
-echo "=== Uploaded files ==="
-$AWS s3 ls "s3://$BUCKET/"
-
-echo ""
-echo "=== Setup complete! ==="
-echo "Run integration tests with:"
-echo "  cargo test -p pcapsql-datafusion --features s3 --test cloud_integration -- --ignored"
+  *)
+    echo "usage: $0 [docker|seaweedfs]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Stage 7/9 — Cloud SeekablePacketSource via byte-range GETs + real object-store tests

Extends the Stage 6 capability to object storage: `CloudPacketSource` becomes seekable with `SeekCost::RangeRequest`, partitioning a remote object via independent byte-range GETs.

**Changes**
- `CloudPacketSource` implements `SeekablePacketSource`: per-partition range GETs, with the cost hint gating whether a small object is worth partitioning.
- Integration tests against a real S3-compatible store (gated on the `s3` feature **and** `PCAPSQL_S3_TEST_ENDPOINT`): byte-range partitioned reads equal the sequential read, exercised live against SeaweedFS/MinIO.
- `testdata/cloud/` harness (docker-compose, SeaweedFS `s3.json`, `setup.sh`) for running a local store.

No issues closed here — completes cloud support for the parallelism that closes #87 in Stage 8.

---
**Stacked on:** #94 (`claude/stack-06-seekable`) · **Stage:** 7 of 9 · **Epic:** #88 · **Supersedes part of:** #78

Every stage compiles and passes `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `cargo check -p pcapsql-datafusion --features s3 --tests` independently.

https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96

---
_Generated by [Claude Code](https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96)_