### PR TITLE
P2 — Query-scoped parse: parsing moves to query time

### DIFF
--- a/pcapsql-core/src/lib.rs
+++ b/pcapsql-core/src/lib.rs
@@ -34,8 +34,9 @@
 //! reader.process_packets(1000, |packet| {
 //!     let results = pcapsql_core::parse_packet(
 //!         &registry,
-//!         packet.link_type as u16,
-//!         &packet.data,
+//!         packet.link_type,
+//!         packet.data,
+//!         &pcapsql_core::ParseScope::full(),
 //!     );
 //!
 //!     for (protocol_name, result) in results {
@@ -101,10 +102,9 @@ pub use io::{MmapPacketReader, MmapPacketSource};
 pub use protocol::OwnedFieldValue;
 pub use protocol::{
     chain_fields_for_protocol, compute_required_protocols, default_registry,
-    merge_with_chain_fields, parse_packet, parse_packet_projected, parse_packet_pruned,
-    parse_packet_pruned_projected, should_continue_parsing, should_run_parser, BuiltinProtocol,
-    FieldValue, ParseContext, ParseResult, PayloadMode, ProjectionConfig, Protocol,
-    ProtocolRegistry, TunnelLayer, TunnelType,
+    merge_with_chain_fields, parse_packet, should_continue_parsing, should_run_parser,
+    BuiltinProtocol, FieldValue, ParseContext, ParseResult, ParseScope, PayloadMode,
+    ProjectionConfig, Protocol, ProtocolRegistry, TunnelLayer, TunnelType,
 };
 pub use schema::{DataKind, FieldDescriptor, ProtocolSchema};
 pub use stream::{

--- a/pcapsql-core/src/prelude.rs
+++ b/pcapsql-core/src/prelude.rs
@@ -20,7 +20,7 @@ pub use crate::schema::{DataKind, FieldDescriptor, ProtocolSchema};
 // Protocol types
 pub use crate::protocol::{
     default_registry, parse_packet, BuiltinProtocol, FieldValue, ParseContext, ParseResult,
-    PayloadMode, Protocol, ProtocolRegistry,
+    ParseScope, PayloadMode, Protocol, ProtocolRegistry,
 };
 
 // I/O types

--- a/pcapsql-core/src/protocol/mod.rs
+++ b/pcapsql-core/src/protocol/mod.rs
@@ -19,7 +19,7 @@
 //! ## Example
 //!
 //! ```rust
-//! use pcapsql_core::protocol::{default_registry, parse_packet};
+//! use pcapsql_core::protocol::{default_registry, parse_packet, ParseScope};
 //!
 //! let registry = default_registry();
 //! // Ethernet frame with IP/TCP
@@ -31,7 +31,7 @@
 //!     // Minimal IPv4 header would follow...
 //! ];
 //!
-//! let results = parse_packet(&registry, 1, packet_data); // 1 = Ethernet
+//! let results = parse_packet(&registry, 1, packet_data, &ParseScope::full());
 //! for (name, result) in results {
 //!     let field_names: Vec<_> = result.fields.iter().map(|(k, _)| *k).collect();
 //!     println!("Parsed {}: {:?}", name, field_names);
@@ -178,332 +178,119 @@ pub fn default_registry() -> ProtocolRegistry {
 
 use std::collections::{HashMap, HashSet};
 
-/// Parse a packet through all protocol layers.
+/// What a parse pass should extract: which protocols to run and which
+/// fields to materialize per protocol.
 ///
-/// For tunneled traffic, this function tracks encapsulation depth and tunnel context.
-/// Each ParseResult includes encap_depth, tunnel_type, and tunnel_id fields that indicate
-/// whether the protocol was parsed inside a tunnel and which tunnel it was in.
+/// Built once per query (or [`ParseScope::full`] for unscoped parsing) and
+/// passed to [`parse_packet`] for every packet. Pruning stops the protocol
+/// walk as soon as everything required has been seen; projection limits the
+/// fields individual parsers extract.
+#[derive(Clone, Debug, Default)]
+pub struct ParseScope {
+    /// Protocols to parse, including their dependency closure. `None` parses
+    /// every matching protocol.
+    required: Option<HashSet<String>>,
+    /// Per-protocol field projections. Protocols absent from the map are
+    /// parsed with all fields.
+    projections: HashMap<String, HashSet<String>>,
+}
+
+impl ParseScope {
+    /// Parse every protocol with every field (the unscoped default).
+    pub fn full() -> Self {
+        Self::default()
+    }
+
+    /// Parse only the given tables' protocols plus their dependency closure
+    /// (via [`compute_required_protocols`]). Unknown table names (pseudo
+    /// tables such as `frames`) are tolerated: they require no parsing.
+    pub fn for_tables(queried_tables: &[&str], registry: &ProtocolRegistry) -> Self {
+        Self {
+            required: Some(compute_required_protocols(queried_tables, registry)),
+            projections: HashMap::new(),
+        }
+    }
+
+    /// Restrict the fields extracted for one protocol.
+    pub fn with_projection(mut self, protocol: impl Into<String>, fields: HashSet<String>) -> Self {
+        self.projections.insert(protocol.into(), fields);
+        self
+    }
+
+    /// True when nothing is pruned or projected.
+    pub fn is_full(&self) -> bool {
+        self.required.is_none() && self.projections.is_empty()
+    }
+}
+
+/// Parse a packet through its protocol layers, scoped by `scope`.
+///
+/// With [`ParseScope::full`] every matching protocol is parsed with all
+/// fields. A scoped parse prunes the protocol walk (stopping once all
+/// required protocols have been seen, and never descending into branches
+/// that cannot reach one) and projects fields within parsers that support
+/// it. Intermediate layers on the path to a required protocol are still
+/// returned — they may be needed for joins.
+///
+/// For tunneled traffic, encapsulation depth and tunnel context are tracked;
+/// each ParseResult carries encap_depth, tunnel_type, and tunnel_id.
 pub fn parse_packet<'a>(
     registry: &ProtocolRegistry,
     link_type: u16,
     data: &'a [u8],
+    scope: &ParseScope,
 ) -> Vec<(&'static str, ParseResult<'a>)> {
-    // Typical packet has 3-4 protocol layers (Eth/IP/TCP/App)
-    // Tunneled packets may have more (up to 8 layers for complex encapsulation)
+    // Typical packet has 3-4 protocol layers (Eth/IP/TCP/App);
+    // tunneled packets may have more (up to ~8 for deep encapsulation).
     let mut results = Vec::with_capacity(8);
+    let mut parsed_protocols: Vec<&str> = Vec::new();
     let mut context = ParseContext::new(link_type);
     let mut remaining = data;
 
     while !remaining.is_empty() {
-        if let Some(parser) = registry.find_parser(&context) {
-            let mut result = parser.parse(remaining, &context);
-
-            // Set encapsulation context on the result BEFORE updating context
-            // This captures the encap state when this protocol was parsed
-            result.set_encap_context(&context);
-
-            // Check if this protocol's child hints indicate a tunnel boundary
-            // If so, update context for the next layer (inner protocols)
-            if let Some(tunnel_type_val) = result.hint("tunnel_type") {
-                let tunnel_id = result.hint("tunnel_id");
-                context.push_tunnel(TunnelType::from_u64(tunnel_type_val), tunnel_id);
-            }
-
-            // Update context for next layer
-            context.parent_protocol = Some(parser.name());
-            context.hints = result.child_hints.clone();
-            context.offset += remaining.len() - result.remaining.len();
-
-            let should_stop = result.error.is_some();
-            remaining = result.remaining;
-
-            results.push((parser.name(), result));
-
-            if should_stop {
+        if let Some(required) = &scope.required {
+            // Stop once every required protocol has been parsed.
+            if !should_continue_parsing(&parsed_protocols, required) {
                 break;
             }
-        } else {
-            break;
-        }
-    }
-
-    results
-}
-
-/// Parse a packet with protocol pruning.
-///
-/// Only parses protocols in the `required` set and their dependencies.
-/// This can significantly reduce CPU usage for selective queries.
-///
-/// # Arguments
-///
-/// * `registry` - Protocol registry containing parser definitions
-/// * `link_type` - Link layer type (e.g., 1 for Ethernet)
-/// * `data` - Raw packet bytes
-/// * `required` - Set of protocol names needed for the query
-///
-/// # Returns
-///
-/// Vector of (protocol_name, parse_result) pairs for protocols in the required set.
-/// Protocols parsed but not in the required set (i.e., intermediate layers) are
-/// still included as they may be needed for correct result interpretation.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// use std::collections::HashSet;
-/// use pcapsql_core::protocol::{default_registry, parse_packet_pruned};
-///
-/// let registry = default_registry();
-/// let required: HashSet<String> = ["tcp"].iter().map(|s| s.to_string()).collect();
-///
-/// let results = parse_packet_pruned(&registry, 1, &packet_data, &required);
-/// // Will parse Ethernet, IPv4/IPv6, TCP but skip DNS, HTTP, TLS, etc.
-/// ```
-pub fn parse_packet_pruned<'a>(
-    registry: &ProtocolRegistry,
-    link_type: u16,
-    data: &'a [u8],
-    required: &HashSet<String>,
-) -> Vec<(&'static str, ParseResult<'a>)> {
-    // If no required set or empty, fall back to full parsing
-    if required.is_empty() {
-        return parse_packet(registry, link_type, data);
-    }
-
-    // Typical packet has 3-4 protocol layers
-    let mut results = Vec::with_capacity(4);
-    let mut parsed_protocols: Vec<&str> = Vec::with_capacity(4);
-    let mut context = ParseContext::new(link_type);
-    let mut remaining = data;
-
-    while !remaining.is_empty() {
-        // Check if we have everything we need
-        if !should_continue_parsing(&parsed_protocols, required) {
-            break;
         }
 
-        // Find next parser
-        let parser = match registry.find_parser(&context) {
-            Some(p) => p,
-            None => break,
+        let Some(parser) = registry.find_parser(&context) else {
+            break;
         };
-
         let name = parser.name();
 
-        // Check if we should run this parser
-        if !should_run_parser(name, required, registry) {
-            // Skip this parser - we don't need it or anything it produces
-            break;
+        if let Some(required) = &scope.required {
+            // Never descend into a branch that cannot reach a required
+            // protocol.
+            if !should_run_parser(name, required, registry) {
+                break;
+            }
+            parsed_protocols.push(name);
         }
 
-        // Parse
-        let mut result = parser.parse(remaining, &context);
-        parsed_protocols.push(name);
+        let mut result = if scope.projections.is_empty() {
+            parser.parse(remaining, &context)
+        } else {
+            parser.parse_projected(remaining, &context, scope.projections.get(name))
+        };
 
-        // Set encapsulation context on the result BEFORE updating context
+        // Set encapsulation context on the result BEFORE updating context;
+        // this captures the encap state when this protocol was parsed.
         result.set_encap_context(&context);
 
-        // Check if this protocol's child hints indicate a tunnel boundary
+        // A tunnel boundary updates context for the inner layers.
         if let Some(tunnel_type_val) = result.hint("tunnel_type") {
             let tunnel_id = result.hint("tunnel_id");
             context.push_tunnel(TunnelType::from_u64(tunnel_type_val), tunnel_id);
         }
 
-        // Update context for next layer
+        // Update context for the next layer.
         context.parent_protocol = Some(name);
         context.hints = result.child_hints.clone();
         context.offset += remaining.len() - result.remaining.len();
 
-        let should_stop = result.error.is_some() || result.remaining.is_empty();
-        remaining = result.remaining;
-
-        // Always add to results - we may need intermediate layers for joins
-        results.push((name, result));
-
-        if should_stop {
-            break;
-        }
-    }
-
-    results
-}
-
-/// Parse a packet with field projection.
-///
-/// Uses `parse_projected()` for each protocol, only extracting the fields
-/// in the projection config. This can significantly reduce CPU usage when
-/// queries only need a subset of fields.
-///
-/// # Arguments
-///
-/// * `registry` - Protocol registry containing parser definitions
-/// * `link_type` - Link layer type (e.g., 1 for Ethernet)
-/// * `data` - Raw packet bytes
-/// * `projections` - Per-protocol field projections (protocol name -> field names)
-///
-/// # Returns
-///
-/// Vector of (protocol_name, parse_result) pairs. Parse results only contain
-/// the fields that were requested in the projection config.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// use std::collections::{HashMap, HashSet};
-/// use pcapsql_core::protocol::{default_registry, parse_packet_projected};
-///
-/// let registry = default_registry();
-///
-/// // Only extract ports from TCP
-/// let mut projections = HashMap::new();
-/// projections.insert("tcp", ["src_port", "dst_port"].iter().map(|s| s.to_string()).collect());
-///
-/// let results = parse_packet_projected(&registry, 1, &packet_data, &projections);
-/// ```
-pub fn parse_packet_projected<'a>(
-    registry: &ProtocolRegistry,
-    link_type: u16,
-    data: &'a [u8],
-    projections: &HashMap<String, HashSet<String>>,
-) -> Vec<(&'static str, ParseResult<'a>)> {
-    // If no projections, fall back to full parsing
-    if projections.is_empty() {
-        return parse_packet(registry, link_type, data);
-    }
-
-    // Typical packet has 3-4 protocol layers
-    let mut results = Vec::with_capacity(4);
-    let mut context = ParseContext::new(link_type);
-    let mut remaining = data;
-
-    while !remaining.is_empty() {
-        if let Some(parser) = registry.find_parser(&context) {
-            let name = parser.name();
-
-            // Get projection for this protocol, if any
-            let projection = projections.get(name);
-
-            // Use projected parsing if projection is configured
-            let mut result = parser.parse_projected(remaining, &context, projection);
-
-            // Set encapsulation context on the result BEFORE updating context
-            result.set_encap_context(&context);
-
-            // Check if this protocol's child hints indicate a tunnel boundary
-            if let Some(tunnel_type_val) = result.hint("tunnel_type") {
-                let tunnel_id = result.hint("tunnel_id");
-                context.push_tunnel(TunnelType::from_u64(tunnel_type_val), tunnel_id);
-            }
-
-            // Update context for next layer
-            context.parent_protocol = Some(name);
-            context.hints = result.child_hints.clone();
-            context.offset += remaining.len() - result.remaining.len();
-
-            let should_stop = result.error.is_some();
-            remaining = result.remaining;
-
-            results.push((name, result));
-
-            if should_stop {
-                break;
-            }
-        } else {
-            break;
-        }
-    }
-
-    results
-}
-
-/// Parse a packet with both protocol pruning and field projection.
-///
-/// This combines the benefits of both optimizations:
-/// - Protocol pruning skips parsing protocols not needed for the query
-/// - Field projection only extracts needed fields within parsed protocols
-///
-/// # Arguments
-///
-/// * `registry` - Protocol registry containing parser definitions
-/// * `link_type` - Link layer type (e.g., 1 for Ethernet)
-/// * `data` - Raw packet bytes
-/// * `required` - Set of protocol names needed for the query (for pruning)
-/// * `projections` - Per-protocol field projections
-///
-/// # Returns
-///
-/// Vector of (protocol_name, parse_result) pairs.
-pub fn parse_packet_pruned_projected<'a>(
-    registry: &ProtocolRegistry,
-    link_type: u16,
-    data: &'a [u8],
-    required: &HashSet<String>,
-    projections: &HashMap<String, HashSet<String>>,
-) -> Vec<(&'static str, ParseResult<'a>)> {
-    // If no pruning or projection, fall back to full parsing
-    if required.is_empty() && projections.is_empty() {
-        return parse_packet(registry, link_type, data);
-    }
-
-    // If only pruning, use pruned parsing
-    if projections.is_empty() {
-        return parse_packet_pruned(registry, link_type, data, required);
-    }
-
-    // If only projection, use projected parsing
-    if required.is_empty() {
-        return parse_packet_projected(registry, link_type, data, projections);
-    }
-
-    // Combined pruning and projection
-    // Typical packet has 3-4 protocol layers
-    let mut results = Vec::with_capacity(4);
-    let mut parsed_protocols: Vec<&str> = Vec::with_capacity(4);
-    let mut context = ParseContext::new(link_type);
-    let mut remaining = data;
-
-    while !remaining.is_empty() {
-        // Check if we have everything we need (pruning)
-        if !should_continue_parsing(&parsed_protocols, required) {
-            break;
-        }
-
-        // Find next parser
-        let parser = match registry.find_parser(&context) {
-            Some(p) => p,
-            None => break,
-        };
-
-        let name = parser.name();
-
-        // Check if we should run this parser (pruning)
-        if !should_run_parser(name, required, registry) {
-            break;
-        }
-
-        // Get projection for this protocol, if any
-        let projection = projections.get(name);
-
-        // Parse with projection
-        let mut result = parser.parse_projected(remaining, &context, projection);
-        parsed_protocols.push(name);
-
-        // Set encapsulation context on the result BEFORE updating context
-        result.set_encap_context(&context);
-
-        // Check if this protocol's child hints indicate a tunnel boundary
-        if let Some(tunnel_type_val) = result.hint("tunnel_type") {
-            let tunnel_id = result.hint("tunnel_id");
-            context.push_tunnel(TunnelType::from_u64(tunnel_type_val), tunnel_id);
-        }
-
-        // Update context for next layer
-        context.parent_protocol = Some(name);
-        context.hints = result.child_hints.clone();
-        context.offset += remaining.len() - result.remaining.len();
-
-        let should_stop = result.error.is_some() || result.remaining.is_empty();
+        let should_stop = result.error.is_some();
         remaining = result.remaining;
 
         results.push((name, result));

--- a/pcapsql-core/src/protocol/netlink.rs
+++ b/pcapsql-core/src/protocol/netlink.rs
@@ -460,13 +460,13 @@ mod tests {
     // ==========================================================================
     #[test]
     fn test_parse_packet_selects_netlink() {
-        use crate::protocol::{default_registry, parse_packet};
+        use crate::protocol::{default_registry, parse_packet, ParseScope};
 
         let registry = default_registry();
         let header = create_netlink_header(32, 16, NLM_F_REQUEST, 1, 1234);
 
         // Parse with link_type 253 (LINKTYPE_NETLINK)
-        let results = parse_packet(&registry, LINKTYPE_NETLINK, &header);
+        let results = parse_packet(&registry, LINKTYPE_NETLINK, &header, &ParseScope::full());
 
         // Should find netlink protocol
         assert!(

--- a/pcapsql-datafusion/benches/baseline.rs
+++ b/pcapsql-datafusion/benches/baseline.rs
@@ -10,7 +10,7 @@
 //! run completes in minutes while still dominating constant overheads.
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
-use pcapsql_core::{default_registry, parse_packet};
+use pcapsql_core::{default_registry, parse_packet, ParseScope};
 use pcapsql_datafusion::query::{EngineOptions, QueryEngine, SourceSpec};
 use pcapsql_testgen::{legacy_pcap, GenPacket, LegacyVariant};
 use tempfile::TempDir;
@@ -96,11 +96,12 @@ fn bench_parse_throughput(c: &mut Criterion) {
 
     let mut g = c.benchmark_group("parse_throughput");
     g.throughput(Throughput::Elements(frames.len() as u64));
+    let scope = ParseScope::full();
     g.bench_function("full_parse_udp", |b| {
         b.iter(|| {
             let mut fields = 0usize;
             for f in &frames {
-                let parsed = parse_packet(&registry, 1, f);
+                let parsed = parse_packet(&registry, 1, f, &scope);
                 fields += parsed.len();
             }
             fields

--- a/pcapsql-datafusion/src/main.rs
+++ b/pcapsql-datafusion/src/main.rs
@@ -97,8 +97,16 @@ async fn main() -> Result<()> {
         InputSource::LocalFile(path) => SourceSpec::Path(path.clone()),
     };
 
+    // One-shot invocations retain nothing; the REPL caches touched tables.
+    let retention = if args.query.is_some() || args.query_file.is_some() {
+        pcapsql_datafusion::query::RetentionPolicy::None
+    } else {
+        pcapsql_datafusion::query::RetentionPolicy::CacheOnTouch
+    };
+
     let opts = EngineOptions {
         batch_size: args.batch_size,
+        retention,
         keylog,
         mmap: !args.no_mmap,
         progress: progress_cb,
@@ -195,14 +203,28 @@ async fn main() -> Result<()> {
 }
 
 fn print_parse_stats(engine: &QueryEngine) {
-    // The parse cache was removed in favor of a single shared parse pass; report
-    // the parse-pass / partition instrumentation instead.
+    let stats = engine.last_parse_stats();
     eprintln!();
+    if stats.parse_passes == 0 {
+        eprintln!("Parse passes: 0 (served from cache)");
+        return;
+    }
     eprintln!(
-        "Parse passes: {}  (partitions: {})",
-        engine.parse_pass_count(),
-        engine.partition_count()
+        "Parse passes: {}  (partitions: {}, packets scanned: {}{})",
+        stats.parse_passes,
+        stats.partitions,
+        stats.packets_scanned,
+        if stats.complete_scan {
+            ""
+        } else {
+            ", stopped early by LIMIT"
+        }
     );
+    let mut rows: Vec<_> = stats.rows_built.iter().filter(|(_, n)| **n > 0).collect();
+    rows.sort();
+    for (table, n) in rows {
+        eprintln!("  {table}: {n} rows");
+    }
 }
 
 fn list_protocols() {
@@ -346,10 +368,10 @@ async fn run_repl(
                     ReplCommand::Protocols => list_protocols(),
                     ReplCommand::Udfs => list_udfs(),
                     ReplCommand::CacheStats => {
+                        let stats = engine.last_parse_stats();
                         println!(
-                            "Parse passes: {}  (partitions: {})",
-                            engine.parse_pass_count(),
-                            engine.partition_count()
+                            "Last query: {} parse pass(es), {} partition(s), {} packets scanned",
+                            stats.parse_passes, stats.partitions, stats.packets_scanned
                         );
                     }
                     ReplCommand::CacheStatsReset => {

--- a/pcapsql-datafusion/src/query/builders/mod.rs
+++ b/pcapsql-datafusion/src/query/builders/mod.rs
@@ -7,16 +7,11 @@
 //! ## Architecture
 //!
 //! ```text
-//! Parsed Packets → NormalizedBatchSet → Multiple Protocol Tables
-//!                        │
-//!                        ├─► frames table
-//!                        ├─► ethernet table
-//!                        ├─► ipv4 table
-//!                        ├─► ipv6 table
-//!                        ├─► tcp table
-//!                        ├─► udp table
-//!                        ├─► dns table
-//!                        └─► ... other protocol tables
+//! Parsed Packets → NormalizedBatchSet → the SUBSCRIBED protocol tables
+//!                        │                  (per-query column subsets,
+//!                        ├─► frames          parse-time predicates and
+//!                        ├─► tcp             row caps applied before any
+//!                        └─► …               Arrow materialization)
 //! ```
 //!
 //! Each protocol table contains only the fields relevant to that protocol,
@@ -27,13 +22,3 @@ mod protocol;
 
 pub use normalized::NormalizedBatchSet;
 pub use protocol::ProtocolBatchBuilder;
-
-use std::collections::HashMap;
-
-use arrow::record_batch::RecordBatch;
-
-/// A collection of RecordBatches for all protocol tables.
-pub type ProtocolBatches = HashMap<String, Vec<RecordBatch>>;
-
-/// A single set of RecordBatches, one per protocol table.
-pub type ProtocolBatchMap = HashMap<String, RecordBatch>;

--- a/pcapsql-datafusion/src/query/builders/normalized.rs
+++ b/pcapsql-datafusion/src/query/builders/normalized.rs
@@ -1,80 +1,78 @@
-//! Normalized batch set builder.
+//! Subscription-scoped batch set builder.
 //!
-//! Orchestrates multiple ProtocolBatchBuilders to create per-protocol tables
-//! from parsed packet data.
+//! Routes parsed packets into Arrow builders for exactly the tables (and
+//! columns) a parse pass subscribes to, applying parse-time predicates and
+//! row caps before any Arrow materialization happens.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
-use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 
 use super::protocol::ProtocolBatchBuilder;
-use crate::error::Error;
-use crate::query::tables;
+use crate::error::{Error, QueryError};
+use crate::query::filter::FilterEvaluator;
+use crate::query::providers::ParseSubscription;
 use pcapsql_core::io::PacketRef;
 use pcapsql_core::ParseResult;
 
-/// A set of batches for all protocol tables.
-pub type ProtocolBatches = HashMap<String, Vec<RecordBatch>>;
+/// Per-table build state within one parse pass.
+struct TableSlot {
+    builder: ProtocolBatchBuilder,
+    batches: Vec<RecordBatch>,
+    predicate: Option<FilterEvaluator>,
+    fetch: Option<usize>,
+    rows_added: usize,
+}
 
-/// Orchestrates multiple ProtocolBatchBuilders to create per-protocol tables.
+impl TableSlot {
+    fn capped(&self) -> bool {
+        self.fetch.is_some_and(|f| self.rows_added >= f)
+    }
+}
+
+/// Routes each packet's parsed layers into the subscribed tables' builders.
 ///
 /// Usage:
 /// ```ignore
-/// let mut batch_set = NormalizedBatchSet::new(1000);
+/// let mut batch_set = NormalizedBatchSet::new(1000, &subscription)?;
 ///
 /// // For each packet (borrowed, zero-copy):
 /// batch_set.add_packet_from_ref(packet_ref, &parsed_results)?;
 ///
-/// // Get all batches when done:
+/// // Get the per-table batches when done:
 /// let batches = batch_set.finish()?;
-/// // batches: HashMap<"frames" -> Vec<RecordBatch>, "tcp" -> Vec<RecordBatch>, ...>
 /// ```
 pub struct NormalizedBatchSet {
-    /// Frames table builder
-    frames_builder: ProtocolBatchBuilder,
-    /// Protocol builders (keyed by table name)
-    protocol_builders: HashMap<String, ProtocolBatchBuilder>,
-    /// Accumulated batches for each protocol
-    batches: ProtocolBatches,
+    slots: HashMap<String, TableSlot>,
 }
 
 impl NormalizedBatchSet {
-    /// Create a new normalized batch set with the given batch size.
-    pub fn new(batch_size: usize) -> Self {
-        let frames_builder =
-            ProtocolBatchBuilder::new("frames", batch_size).expect("frames schema should exist");
-
-        let mut protocol_builders = HashMap::new();
-
-        // Create builders for all protocol tables (except frames)
-        for table_name in tables::all_table_names() {
-            if table_name == "frames" {
-                continue;
-            }
-            if let Some(builder) = ProtocolBatchBuilder::new(table_name, batch_size) {
-                protocol_builders.insert(table_name.to_string(), builder);
-            }
+    /// Create builders for exactly the subscribed tables, each over its
+    /// (possibly column-subset) schema.
+    pub fn new(batch_size: usize, subscription: &ParseSubscription) -> Result<Self, Error> {
+        let mut slots = HashMap::with_capacity(subscription.tables.len());
+        for (name, sub) in &subscription.tables {
+            let schema = subscription.table_schema(name).ok_or_else(|| {
+                Error::Query(QueryError::Execution(format!("Unknown table: {name}")))
+            })?;
+            slots.insert(
+                name.clone(),
+                TableSlot {
+                    builder: ProtocolBatchBuilder::with_schema(name.clone(), schema, batch_size),
+                    batches: Vec::new(),
+                    predicate: sub.predicate.clone(),
+                    fetch: sub.fetch,
+                    rows_added: 0,
+                },
+            );
         }
-
-        let mut batches = HashMap::new();
-        batches.insert("frames".to_string(), Vec::new());
-        for name in tables::all_table_names() {
-            batches.insert(name.to_string(), Vec::new());
-        }
-
-        Self {
-            frames_builder,
-            protocol_builders,
-            batches,
-        }
+        Ok(Self { slots })
     }
 
-    /// Add a packet to all relevant protocol tables.
+    /// Add a packet to the subscribed tables.
     ///
     /// `packet` is a borrowed (zero-copy) reference to the packet data.
-    /// `parsed` is the chain of parsed protocol layers from parse_packet().
+    /// `parsed` is the chain of parsed protocol layers from `parse_packet`.
     pub fn add_packet_from_ref(
         &mut self,
         packet: PacketRef<'_>,
@@ -82,33 +80,43 @@ impl NormalizedBatchSet {
     ) -> Result<(), Error> {
         let frame_number = packet.frame_number;
 
-        // Always add to frames table
-        self.frames_builder.add_frame_from_raw(
-            packet.frame_number,
-            packet.timestamp_ns,
-            packet.captured_len,
-            packet.original_len,
-            packet.data,
-            packet.link_type,
-        );
-        if let Some(batch) = self.frames_builder.try_build()? {
-            self.batches
-                .get_mut("frames")
-                .expect("frames batches should exist")
-                .push(batch);
+        // The frames table is fed from packet metadata, not parse results.
+        if let Some(slot) = self.slots.get_mut("frames") {
+            // Predicates on frames are never pushed down (metadata fields are
+            // not parse fields); only the row cap applies.
+            if !slot.capped() {
+                slot.builder.add_frame_from_raw(
+                    packet.frame_number,
+                    packet.timestamp_ns,
+                    packet.captured_len,
+                    packet.original_len,
+                    packet.data,
+                    packet.link_type,
+                );
+                slot.rows_added += 1;
+                if let Some(batch) = slot.builder.try_build()? {
+                    slot.batches.push(batch);
+                }
+            }
         }
 
-        // Route each parsed protocol to its table
+        // Route each parsed protocol layer to its table, if subscribed.
         for (proto_name, result) in parsed {
-            // Find the table name for this protocol
-            if let Some(builder) = self.protocol_builders.get_mut(*proto_name) {
-                builder.add_parsed_row(frame_number, result);
-
-                if let Some(batch) = builder.try_build()? {
-                    self.batches
-                        .get_mut(*proto_name)
-                        .expect("protocol batches should exist")
-                        .push(batch);
+            if let Some(slot) = self.slots.get_mut(*proto_name) {
+                if slot.capped() {
+                    continue;
+                }
+                if let Some(predicate) = &slot.predicate {
+                    // Conservative: only a positively-false comparison drops
+                    // the row; DataFusion re-checks everything kept.
+                    if !predicate.matches_result(result) {
+                        continue;
+                    }
+                }
+                slot.builder.add_parsed_row(frame_number, result);
+                slot.rows_added += 1;
+                if let Some(batch) = slot.builder.try_build()? {
+                    slot.batches.push(batch);
                 }
             }
         }
@@ -116,60 +124,30 @@ impl NormalizedBatchSet {
         Ok(())
     }
 
-    /// Finish building and return all batches.
-    ///
-    /// Returns a HashMap mapping table names to vectors of RecordBatches.
-    pub fn finish(mut self) -> Result<ProtocolBatches, Error> {
-        // Finish frames table
-        if let Some(batch) = self.frames_builder.finish()? {
-            self.batches
-                .get_mut("frames")
-                .expect("frames batches should exist")
-                .push(batch);
-        }
+    /// True when every subscribed table has reached its row cap — the parse
+    /// loop can stop reading the source.
+    pub fn all_capped(&self) -> bool {
+        !self.slots.is_empty() && self.slots.values().all(TableSlot::capped)
+    }
 
-        // Finish all protocol tables
-        for (name, mut builder) in self.protocol_builders {
-            if let Some(batch) = builder.finish()? {
-                self.batches
-                    .get_mut(&name)
-                    .expect("protocol batches should exist")
-                    .push(batch);
+    /// Finish building and return the per-table batches.
+    pub fn finish(self) -> Result<HashMap<String, Vec<RecordBatch>>, Error> {
+        let mut out = HashMap::with_capacity(self.slots.len());
+        for (name, mut slot) in self.slots {
+            if let Some(batch) = slot.builder.finish()? {
+                slot.batches.push(batch);
             }
+            out.insert(name, slot.batches);
         }
-
-        Ok(self.batches)
+        Ok(out)
     }
 
-    /// Get the schema for a specific table.
-    pub fn get_schema(table_name: &str) -> Option<Arc<Schema>> {
-        tables::get_table_schema(table_name).map(Arc::new)
-    }
-
-    /// Get all table names.
-    pub fn table_names() -> Vec<&'static str> {
-        tables::all_table_names()
-    }
-
-    /// Get the number of rows added to a specific table.
+    /// Rows added to a table so far (pending and built).
     pub fn row_count(&self, table_name: &str) -> usize {
-        if table_name == "frames" {
-            self.frames_builder.row_count()
-                + self
-                    .batches
-                    .get("frames")
-                    .map(|b| b.iter().map(|rb| rb.num_rows()).sum())
-                    .unwrap_or(0)
-        } else if let Some(builder) = self.protocol_builders.get(table_name) {
-            builder.row_count()
-                + self
-                    .batches
-                    .get(table_name)
-                    .map(|b| b.iter().map(|rb| rb.num_rows()).sum())
-                    .unwrap_or(0)
-        } else {
-            0
-        }
+        self.slots
+            .get(table_name)
+            .map(|s| s.rows_added)
+            .unwrap_or(0)
     }
 }
 
@@ -177,8 +155,11 @@ impl NormalizedBatchSet {
 mod tests {
     use super::*;
     use compact_str::CompactString;
+    use datafusion::logical_expr::col;
+    use datafusion::prelude::lit;
     use pcapsql_core::{FieldValue, TunnelType};
     use smallvec::SmallVec;
+    use std::collections::HashSet;
 
     const TEST_DATA: [u8; 100] = [0u8; 100];
 
@@ -216,38 +197,11 @@ mod tests {
         }
     }
 
-    fn create_ipv4_result<'a>() -> ParseResult<'a> {
-        let mut fields = SmallVec::new();
-        fields.push(("version", FieldValue::UInt8(4)));
-        fields.push((
-            "src_ip",
-            FieldValue::IpAddr(std::net::IpAddr::V4("192.168.1.1".parse().unwrap())),
-        ));
-        fields.push((
-            "dst_ip",
-            FieldValue::IpAddr(std::net::IpAddr::V4("192.168.1.2".parse().unwrap())),
-        ));
-        fields.push(("ttl", FieldValue::UInt8(64)));
-        fields.push(("protocol", FieldValue::UInt8(6)));
-
-        ParseResult {
-            fields,
-            remaining: &[],
-            child_hints: SmallVec::new(),
-            error: None,
-            encap_depth: 0,
-            tunnel_type: TunnelType::None,
-            tunnel_id: None,
-        }
-    }
-
-    fn create_tcp_result<'a>() -> ParseResult<'a> {
+    fn create_tcp_result<'a>(dst_port: u16) -> ParseResult<'a> {
         let mut fields = SmallVec::new();
         fields.push(("src_port", FieldValue::UInt16(12345)));
-        fields.push(("dst_port", FieldValue::UInt16(80)));
+        fields.push(("dst_port", FieldValue::UInt16(dst_port)));
         fields.push(("seq", FieldValue::UInt32(100)));
-        fields.push(("ack", FieldValue::UInt32(0)));
-        fields.push(("flags", FieldValue::UInt16(0x02)));
 
         ParseResult {
             fields,
@@ -260,232 +214,119 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_normalized_batch_set_new() {
-        let batch_set = NormalizedBatchSet::new(1000);
-
-        // Check that all expected tables are present
-        assert!(batch_set.batches.contains_key("frames"));
-        assert!(batch_set.batches.contains_key("ethernet"));
-        assert!(batch_set.batches.contains_key("tcp"));
-        assert!(batch_set.batches.contains_key("dns"));
-    }
-
-    #[test]
-    fn test_add_packet_frames_only() {
-        let mut batch_set = NormalizedBatchSet::new(1000);
-
-        let raw = create_test_packet(1);
-        let parsed: Vec<(&'static str, ParseResult)> = vec![];
-
-        batch_set.add_packet_from_ref(raw, &parsed).unwrap();
-
-        // Frames should have 1 row (pending)
-        assert_eq!(batch_set.frames_builder.row_count(), 1);
-    }
-
-    #[test]
-    fn test_add_packet_with_protocols() {
-        let mut batch_set = NormalizedBatchSet::new(1000);
-
-        let raw = create_test_packet(1);
-        let eth = create_ethernet_result();
-        let ipv4 = create_ipv4_result();
-        let tcp = create_tcp_result();
-
-        let parsed: Vec<(&'static str, ParseResult)> =
-            vec![("ethernet", eth), ("ipv4", ipv4), ("tcp", tcp)];
-
-        batch_set.add_packet_from_ref(raw, &parsed).unwrap();
-
-        // Check that rows were added
-        assert_eq!(batch_set.frames_builder.row_count(), 1);
-        assert_eq!(
-            batch_set
-                .protocol_builders
-                .get("ethernet")
-                .unwrap()
-                .row_count(),
-            1
-        );
-        assert_eq!(
-            batch_set.protocol_builders.get("ipv4").unwrap().row_count(),
-            1
-        );
-        assert_eq!(
-            batch_set.protocol_builders.get("tcp").unwrap().row_count(),
-            1
-        );
-    }
-
-    #[test]
-    fn test_finish_produces_batches() {
-        let mut batch_set = NormalizedBatchSet::new(1000);
-
-        for i in 1..=10 {
-            let raw = create_test_packet(i);
-            let eth = create_ethernet_result();
-            let ipv4 = create_ipv4_result();
-            let tcp = create_tcp_result();
-
-            let parsed: Vec<(&'static str, ParseResult)> =
-                vec![("ethernet", eth), ("ipv4", ipv4), ("tcp", tcp)];
-
-            batch_set.add_packet_from_ref(raw, &parsed).unwrap();
-        }
-
-        let batches = batch_set.finish().unwrap();
-
-        // Check that all tables have batches
-        assert!(!batches.get("frames").unwrap().is_empty());
-        assert!(!batches.get("ethernet").unwrap().is_empty());
-        assert!(!batches.get("ipv4").unwrap().is_empty());
-        assert!(!batches.get("tcp").unwrap().is_empty());
-
-        // UDP should be empty (no UDP packets added)
-        assert!(batches.get("udp").unwrap().is_empty());
-
-        // Check row counts
-        let frames_rows: usize = batches
-            .get("frames")
-            .unwrap()
-            .iter()
-            .map(|b| b.num_rows())
-            .sum();
-        assert_eq!(frames_rows, 10);
-    }
-
-    #[test]
-    fn test_batch_size_triggers_build() {
-        let mut batch_set = NormalizedBatchSet::new(5);
-
-        for i in 1..=7 {
-            let raw = create_test_packet(i);
-            let eth = create_ethernet_result();
-
-            let parsed: Vec<(&'static str, ParseResult)> = vec![("ethernet", eth)];
-
-            batch_set.add_packet_from_ref(raw, &parsed).unwrap();
-        }
-
-        // Should have built one batch of 5 for frames and ethernet
-        assert_eq!(batch_set.batches.get("frames").unwrap().len(), 1);
-        assert_eq!(batch_set.batches.get("ethernet").unwrap().len(), 1);
-
-        // Pending rows should be 2
-        assert_eq!(batch_set.frames_builder.row_count(), 2);
-        assert_eq!(
-            batch_set
-                .protocol_builders
-                .get("ethernet")
-                .unwrap()
-                .row_count(),
-            2
-        );
-    }
-
-    #[test]
-    fn test_protocol_isolation() {
-        let mut batch_set = NormalizedBatchSet::new(1000);
-
-        // Add one TCP packet
-        let raw1 = create_test_packet(1);
-        let eth1 = create_ethernet_result();
-        let ipv4_1 = create_ipv4_result();
-        let tcp1 = create_tcp_result();
-        let parsed1: Vec<(&'static str, ParseResult)> =
-            vec![("ethernet", eth1), ("ipv4", ipv4_1), ("tcp", tcp1)];
-        batch_set.add_packet_from_ref(raw1, &parsed1).unwrap();
-
-        // Add one DNS packet (UDP)
-        let raw2 = create_test_packet(2);
-        let eth2 = create_ethernet_result();
-        let ipv4_2 = create_ipv4_result();
-
-        let mut udp_fields = SmallVec::new();
-        udp_fields.push(("src_port", FieldValue::UInt16(12345)));
-        udp_fields.push(("dst_port", FieldValue::UInt16(53)));
-        let udp = ParseResult {
-            fields: udp_fields,
-            remaining: &[],
-            child_hints: SmallVec::new(),
-            error: None,
-            encap_depth: 0,
-            tunnel_type: TunnelType::None,
-            tunnel_id: None,
-        };
-
-        let mut dns_fields = SmallVec::new();
-        dns_fields.push((
+    fn create_dns_result<'a>() -> ParseResult<'a> {
+        let mut fields = SmallVec::new();
+        fields.push((
             "query_name",
             FieldValue::OwnedString(CompactString::new("example.com")),
         ));
-        dns_fields.push(("query_type", FieldValue::UInt16(1)));
-        dns_fields.push(("is_query", FieldValue::Bool(true)));
-        let dns = ParseResult {
-            fields: dns_fields,
+        fields.push(("is_query", FieldValue::Bool(true)));
+        ParseResult {
+            fields,
             remaining: &[],
             child_hints: SmallVec::new(),
             error: None,
             encap_depth: 0,
             tunnel_type: TunnelType::None,
             tunnel_id: None,
-        };
+        }
+    }
 
-        let parsed2: Vec<(&'static str, ParseResult)> = vec![
-            ("ethernet", eth2),
-            ("ipv4", ipv4_2),
-            ("udp", udp),
-            ("dns", dns),
-        ];
-        batch_set.add_packet_from_ref(raw2, &parsed2).unwrap();
-
-        let batches = batch_set.finish().unwrap();
-
-        // TCP table should have 1 row
-        let tcp_rows: usize = batches
-            .get("tcp")
-            .unwrap()
-            .iter()
-            .map(|b| b.num_rows())
-            .sum();
-        assert_eq!(tcp_rows, 1);
-
-        // UDP table should have 1 row
-        let udp_rows: usize = batches
-            .get("udp")
-            .unwrap()
-            .iter()
-            .map(|b| b.num_rows())
-            .sum();
-        assert_eq!(udp_rows, 1);
-
-        // DNS table should have 1 row
-        let dns_rows: usize = batches
-            .get("dns")
-            .unwrap()
-            .iter()
-            .map(|b| b.num_rows())
-            .sum();
-        assert_eq!(dns_rows, 1);
-
-        // Frames should have 2 rows
-        let frames_rows: usize = batches
-            .get("frames")
-            .unwrap()
-            .iter()
-            .map(|b| b.num_rows())
-            .sum();
-        assert_eq!(frames_rows, 2);
+    fn sub_full(names: &[&str]) -> ParseSubscription {
+        ParseSubscription::tables_full(names.iter().map(|s| s.to_string()))
     }
 
     #[test]
-    fn test_table_names() {
-        let names = NormalizedBatchSet::table_names();
-        assert!(names.contains(&"frames"));
-        assert!(names.contains(&"ethernet"));
-        assert!(names.contains(&"tcp"));
-        assert!(names.contains(&"dns"));
-        assert!(names.contains(&"tls"));
+    fn builds_only_subscribed_tables() {
+        let mut bs = NormalizedBatchSet::new(1000, &sub_full(&["frames", "tcp"])).unwrap();
+        let parsed = vec![
+            ("ethernet", create_ethernet_result()),
+            ("tcp", create_tcp_result(80)),
+            ("dns", create_dns_result()),
+        ];
+        bs.add_packet_from_ref(create_test_packet(1), &parsed)
+            .unwrap();
+
+        assert_eq!(bs.row_count("frames"), 1);
+        assert_eq!(bs.row_count("tcp"), 1);
+        // Unsubscribed layers are dropped, not built.
+        assert_eq!(bs.row_count("ethernet"), 0);
+        assert_eq!(bs.row_count("dns"), 0);
+
+        let batches = bs.finish().unwrap();
+        assert_eq!(batches.len(), 2);
+        assert!(batches.contains_key("frames"));
+        assert!(batches.contains_key("tcp"));
+    }
+
+    #[test]
+    fn column_subset_schema_is_materialized() {
+        let mut sub = sub_full(&["tcp"]);
+        sub.tables.get_mut("tcp").unwrap().columns = Some(HashSet::from([
+            "frame_number".to_string(),
+            "dst_port".to_string(),
+        ]));
+
+        let mut bs = NormalizedBatchSet::new(1000, &sub).unwrap();
+        let parsed = vec![("tcp", create_tcp_result(80))];
+        bs.add_packet_from_ref(create_test_packet(1), &parsed)
+            .unwrap();
+
+        let batches = bs.finish().unwrap();
+        let tcp = &batches["tcp"];
+        assert_eq!(tcp.len(), 1);
+        let schema = tcp[0].schema();
+        assert_eq!(schema.fields().len(), 2);
+        assert!(schema.field_with_name("frame_number").is_ok());
+        assert!(schema.field_with_name("dst_port").is_ok());
+        assert!(schema.field_with_name("src_port").is_err());
+    }
+
+    #[test]
+    fn predicate_drops_only_positively_false_rows() {
+        let mut sub = sub_full(&["tcp"]);
+        sub.tables.get_mut("tcp").unwrap().predicate =
+            FilterEvaluator::try_from_exprs(&[col("dst_port").eq(lit(443i32))]);
+
+        let mut bs = NormalizedBatchSet::new(1000, &sub).unwrap();
+        bs.add_packet_from_ref(create_test_packet(1), &[("tcp", create_tcp_result(80))])
+            .unwrap();
+        bs.add_packet_from_ref(create_test_packet(2), &[("tcp", create_tcp_result(443))])
+            .unwrap();
+
+        assert_eq!(bs.row_count("tcp"), 1);
+    }
+
+    #[test]
+    fn fetch_caps_rows_and_reports_all_capped() {
+        let mut sub = sub_full(&["frames"]);
+        sub.tables.get_mut("frames").unwrap().fetch = Some(2);
+
+        let mut bs = NormalizedBatchSet::new(1000, &sub).unwrap();
+        for i in 1..=5 {
+            bs.add_packet_from_ref(create_test_packet(i), &[]).unwrap();
+        }
+        assert_eq!(bs.row_count("frames"), 2);
+        assert!(bs.all_capped());
+    }
+
+    #[test]
+    fn batch_size_triggers_intermediate_batches() {
+        let mut bs = NormalizedBatchSet::new(2, &sub_full(&["frames"])).unwrap();
+        for i in 1..=5 {
+            bs.add_packet_from_ref(create_test_packet(i), &[]).unwrap();
+        }
+        let batches = bs.finish().unwrap();
+        let frames = &batches["frames"];
+        // 5 rows at batch size 2 -> 2 full batches + 1 partial.
+        assert_eq!(frames.len(), 3);
+        let total: usize = frames.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 5);
+    }
+
+    #[test]
+    fn unknown_table_errors() {
+        let result = NormalizedBatchSet::new(1000, &sub_full(&["nonexistent"]));
+        assert!(result.is_err());
     }
 }

--- a/pcapsql-datafusion/src/query/builders/protocol.rs
+++ b/pcapsql-datafusion/src/query/builders/protocol.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use arrow::array::*;
 use arrow::datatypes::{DataType, Schema, TimeUnit};
 use arrow::error::ArrowError;
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 
 use crate::error::{Error, QueryError};
 use crate::query::tables;
@@ -553,8 +553,16 @@ impl ProtocolBatchBuilder {
     fn build_batch(&mut self) -> Result<RecordBatch, Error> {
         let arrays: Vec<Arc<dyn Array>> = self.builders.iter_mut().map(|b| b.finish()).collect();
 
-        let batch = RecordBatch::try_new(self.schema.clone(), arrays)
-            .map_err(|e: ArrowError| Error::Query(QueryError::Arrow(e.to_string())))?;
+        // A fully projected-away schema (e.g. `SELECT count(*)`) still needs
+        // its row count carried.
+        let batch = if arrays.is_empty() {
+            let options = RecordBatchOptions::new().with_row_count(Some(self.rows));
+            RecordBatch::try_new_with_options(self.schema.clone(), arrays, &options)
+                .map_err(|e: ArrowError| Error::Query(QueryError::Arrow(e.to_string())))?
+        } else {
+            RecordBatch::try_new(self.schema.clone(), arrays)
+                .map_err(|e: ArrowError| Error::Query(QueryError::Arrow(e.to_string())))?
+        };
 
         // Reset builders for next batch
         self.rows = 0;

--- a/pcapsql-datafusion/src/query/filter.rs
+++ b/pcapsql-datafusion/src/query/filter.rs
@@ -1,8 +1,15 @@
-//! Filter pushdown evaluation for streaming queries.
+//! Parse-time predicate evaluation for scoped parsing.
 //!
-//! This module provides a way to evaluate simple WHERE clause predicates
-//! against parsed packet fields without going through DataFusion's full
-//! expression evaluation machinery.
+//! Converts simple DataFusion `WHERE` expressions (pushed into `TableScan`s
+//! as `Inexact` filters) into predicates evaluated against a protocol's
+//! [`ParseResult`] *before* a row is materialized into Arrow.
+//!
+//! Evaluation is **table-scoped and conservative**: a field is resolved only
+//! within the row's own protocol layer, and any uncertainty — missing field,
+//! type mismatch, unsupported expression shape — keeps the row. DataFusion
+//! re-applies the original filter (`Inexact` pushdown), so a kept row can
+//! never produce a wrong result; only a *positively false* comparison may
+//! drop a row early.
 
 use datafusion::common::ScalarValue;
 use datafusion::logical_expr::{BinaryExpr, Expr, Operator};
@@ -59,237 +66,163 @@ impl CompareOp {
     }
 }
 
-/// A simple predicate that can be evaluated against packet data.
+/// A simple predicate evaluable against one protocol layer's fields.
 #[derive(Debug, Clone)]
 pub enum SimplePredicate {
-    /// String equality: column = 'value'
+    /// String comparison: `column <op> 'value'`.
     StringCompare {
         field: String,
         op: CompareOp,
         value: String,
     },
-    /// Integer comparison: column <op> value
+    /// Integer comparison: `column <op> value`.
     IntCompare {
         field: String,
         op: CompareOp,
         value: i64,
     },
-    /// Protocol equality: protocol = 'TCP'
-    ProtocolEquals { value: String },
-    /// AND of two predicates
+    /// AND of two predicates.
     And(Box<SimplePredicate>, Box<SimplePredicate>),
-    /// Always true (used for unsupported filters that DataFusion will handle)
+    /// Always keep the row (unsupported shape; DataFusion re-checks).
     AlwaysTrue,
 }
 
+/// Resolve a field value to i64 the way the Arrow column would compare.
+///
+/// IPv4 addresses map to their `u32` column representation. Anything not
+/// confidently mappable returns `None` (⇒ keep the row).
+fn field_as_i64(value: &FieldValue) -> Option<i64> {
+    match value {
+        FieldValue::UInt8(v) => Some(*v as i64),
+        FieldValue::UInt16(v) => Some(*v as i64),
+        FieldValue::UInt32(v) => Some(*v as i64),
+        FieldValue::UInt64(v) => i64::try_from(*v).ok(),
+        FieldValue::Int64(v) => Some(*v),
+        FieldValue::Bool(v) => Some(*v as i64),
+        FieldValue::IpAddr(std::net::IpAddr::V4(v4)) => Some(u32::from(*v4) as i64),
+        _ => None,
+    }
+}
+
+/// Resolve a field value to a string only when the Arrow column is a string.
+fn field_as_str<'v>(value: &'v FieldValue) -> Option<&'v str> {
+    match value {
+        FieldValue::Str(s) => Some(s),
+        FieldValue::OwnedString(s) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
 impl SimplePredicate {
-    /// Evaluate this predicate against parsed packet data.
-    pub fn matches<'a, 'b>(&self, parsed: &'a [(&'static str, ParseResult<'b>)]) -> bool {
+    /// Evaluate against one protocol layer's parse result.
+    ///
+    /// Returns `false` only for a positively-false comparison; any
+    /// uncertainty keeps the row.
+    pub fn matches_result(&self, result: &ParseResult<'_>) -> bool {
         match self {
             SimplePredicate::StringCompare { field, op, value } => {
-                if let Some(field_value) = get_field_value(parsed, field) {
-                    if let Some(s) = field_value.as_string() {
-                        return op.compare_str(&s, value);
-                    }
+                match result.get(field).and_then(field_as_str) {
+                    Some(s) => op.compare_str(s, value),
+                    None => true, // unknown ⇒ keep; DataFusion decides
                 }
-                // Field not found or not a string - doesn't match (unless NotEq)
-                *op == CompareOp::NotEq
             }
             SimplePredicate::IntCompare { field, op, value } => {
-                if let Some(field_value) = get_field_value(parsed, field) {
-                    if let Some(v) = field_value.as_i64() {
-                        return op.compare_i64(v, *value);
-                    }
+                match result.get(field).and_then(field_as_i64) {
+                    Some(v) => op.compare_i64(v, *value),
+                    None => true,
                 }
-                // Field not found or not numeric - doesn't match (unless NotEq)
-                *op == CompareOp::NotEq
             }
-            SimplePredicate::ProtocolEquals { value } => {
-                // Check transport protocol name
-                let protocol = get_protocol_name(parsed);
-                protocol.is_some_and(|p| p.eq_ignore_ascii_case(value))
+            SimplePredicate::And(left, right) => {
+                left.matches_result(result) && right.matches_result(result)
             }
-            SimplePredicate::And(left, right) => left.matches(parsed) && right.matches(parsed),
             SimplePredicate::AlwaysTrue => true,
         }
     }
-}
 
-/// Get a field value from parsed packet data.
-fn get_field_value<'a, 'b>(
-    parsed: &'a [(&'static str, ParseResult<'b>)],
-    field_name: &str,
-) -> Option<&'a FieldValue<'b>> {
-    // Handle common field mappings
-    match field_name {
-        // Ethernet fields
-        "eth_src" => find_field(parsed, "ethernet", "src_mac"),
-        "eth_dst" => find_field(parsed, "ethernet", "dst_mac"),
-        "eth_type" => find_field(parsed, "ethernet", "ethertype"),
-        // IP fields
-        "src_ip" => {
-            find_field(parsed, "ipv4", "src_ip").or_else(|| find_field(parsed, "ipv6", "src_ip"))
-        }
-        "dst_ip" => {
-            find_field(parsed, "ipv4", "dst_ip").or_else(|| find_field(parsed, "ipv6", "dst_ip"))
-        }
-        "ip_ttl" => {
-            find_field(parsed, "ipv4", "ttl").or_else(|| find_field(parsed, "ipv6", "hop_limit"))
-        }
-        "ip_protocol" => find_field(parsed, "ipv4", "protocol")
-            .or_else(|| find_field(parsed, "ipv6", "next_header")),
-        // Port fields
-        "src_port" => {
-            find_field(parsed, "tcp", "src_port").or_else(|| find_field(parsed, "udp", "src_port"))
-        }
-        "dst_port" => {
-            find_field(parsed, "tcp", "dst_port").or_else(|| find_field(parsed, "udp", "dst_port"))
-        }
-        // TCP fields
-        "tcp_flags" => find_field(parsed, "tcp", "flags"),
-        "tcp_seq" => find_field(parsed, "tcp", "seq"),
-        "tcp_ack" => find_field(parsed, "tcp", "ack"),
-        // ICMP fields
-        "icmp_type" => find_field(parsed, "icmp", "type"),
-        "icmp_code" => find_field(parsed, "icmp", "code"),
-        // Frame fields - need to be handled at a higher level
-        "frame_number" | "timestamp" | "length" | "original_length" | "payload_length" => None,
-        // Try to find in any protocol
-        _ => {
-            for (_, result) in parsed {
-                if let Some(v) = result.get(field_name) {
-                    return Some(v);
-                }
-            }
-            None
+    /// True when this predicate can never drop a row.
+    pub fn is_always_true(&self) -> bool {
+        match self {
+            SimplePredicate::AlwaysTrue => true,
+            SimplePredicate::And(l, r) => l.is_always_true() && r.is_always_true(),
+            _ => false,
         }
     }
 }
 
-/// Find a field in a specific protocol's parse result.
-fn find_field<'a, 'b>(
-    parsed: &'a [(&'static str, ParseResult<'b>)],
-    protocol: &str,
-    field: &str,
-) -> Option<&'a FieldValue<'b>> {
-    parsed
-        .iter()
-        .find(|(name, _)| *name == protocol)
-        .and_then(|(_, result)| result.get(field))
-}
-
-/// Get the transport protocol name from parsed data.
-fn get_protocol_name(parsed: &[(&'static str, ParseResult)]) -> Option<&'static str> {
-    for (name, _) in parsed.iter().rev() {
-        match *name {
-            "tcp" => return Some("TCP"),
-            "udp" => return Some("UDP"),
-            "icmp" => return Some("ICMP"),
-            _ => {}
-        }
-    }
-    // Check if we at least have IP
-    for (name, _) in parsed {
-        if *name == "ipv4" || *name == "ipv6" {
-            return Some("IP");
-        }
-    }
-    None
-}
-
-/// Filter evaluator for streaming queries.
+/// Parse-time filter for one table's scan.
 #[derive(Debug, Clone)]
 pub struct FilterEvaluator {
     predicate: SimplePredicate,
 }
 
 impl FilterEvaluator {
-    /// Try to create a filter evaluator from DataFusion expressions.
+    /// Build an evaluator from a scan's pushed-down filter expressions.
     ///
-    /// Returns None if none of the expressions can be pushed down.
-    /// For expressions we can't handle, we include AlwaysTrue predicates
-    /// and let DataFusion filter the results.
+    /// Returns `None` when nothing useful can be evaluated at parse time
+    /// (every expression converts to [`SimplePredicate::AlwaysTrue`]).
     pub fn try_from_exprs(exprs: &[Expr]) -> Option<Self> {
         if exprs.is_empty() {
             return None;
         }
 
-        // Convert each expression and AND them together
-        let mut predicates: Vec<SimplePredicate> = Vec::new();
-        let mut has_pushable = false;
-
-        for expr in exprs {
-            if let Some(pred) = convert_expr(expr) {
-                if !matches!(pred, SimplePredicate::AlwaysTrue) {
-                    has_pushable = true;
-                }
-                predicates.push(pred);
-            } else {
-                predicates.push(SimplePredicate::AlwaysTrue);
-            }
-        }
-
-        if !has_pushable {
-            return None;
-        }
-
-        // Combine all predicates with AND
+        let predicates: Vec<SimplePredicate> = exprs.iter().map(convert_expr).collect();
         let predicate = predicates
             .into_iter()
             .reduce(|acc, pred| SimplePredicate::And(Box::new(acc), Box::new(pred)))
             .unwrap_or(SimplePredicate::AlwaysTrue);
 
+        if predicate.is_always_true() {
+            return None;
+        }
         Some(Self { predicate })
     }
 
-    /// Evaluate the filter against parsed packet data.
-    pub fn matches<'a, 'b>(&self, parsed: &'a [(&'static str, ParseResult<'b>)]) -> bool {
-        self.predicate.matches(parsed)
+    /// Whether an expression contributes a parse-time-evaluable predicate
+    /// (drives the provider's `Inexact` vs `Unsupported` pushdown answer).
+    pub fn expr_is_pushable(expr: &Expr) -> bool {
+        !convert_expr(expr).is_always_true()
+    }
+
+    /// Evaluate against one protocol layer's parse result (conservative).
+    pub fn matches_result(&self, result: &ParseResult<'_>) -> bool {
+        self.predicate.matches_result(result)
     }
 }
 
-/// Convert a DataFusion expression to a simple predicate.
-fn convert_expr(expr: &Expr) -> Option<SimplePredicate> {
+/// Convert a DataFusion expression to a simple predicate (conservative:
+/// anything unsupported becomes [`SimplePredicate::AlwaysTrue`]).
+fn convert_expr(expr: &Expr) -> SimplePredicate {
     match expr {
         Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
             convert_binary_expr(left.as_ref(), op, right.as_ref())
         }
-        Expr::Column(_) => {
-            // A column by itself is truthy if non-null, but we can't easily check
-            Some(SimplePredicate::AlwaysTrue)
-        }
-        _ => Some(SimplePredicate::AlwaysTrue),
+        _ => SimplePredicate::AlwaysTrue,
     }
 }
 
 /// Convert a binary expression to a simple predicate.
-fn convert_binary_expr(left: &Expr, op: &Operator, right: &Expr) -> Option<SimplePredicate> {
-    // Handle AND
+fn convert_binary_expr(left: &Expr, op: &Operator, right: &Expr) -> SimplePredicate {
+    // AND splits; both sides evaluated conservatively.
     if *op == Operator::And {
-        let left_pred = convert_expr(left)?;
-        let right_pred = convert_expr(right)?;
-        return Some(SimplePredicate::And(
-            Box::new(left_pred),
-            Box::new(right_pred),
-        ));
+        return SimplePredicate::And(Box::new(convert_expr(left)), Box::new(convert_expr(right)));
     }
 
-    // Handle OR - we can't short-circuit efficiently, so return AlwaysTrue
+    // OR cannot be short-circuited conservatively per side: keep the row.
     if *op == Operator::Or {
-        return Some(SimplePredicate::AlwaysTrue);
+        return SimplePredicate::AlwaysTrue;
     }
 
-    // Handle comparison operators
-    let compare_op = CompareOp::from_datafusion(op)?;
+    let Some(compare_op) = CompareOp::from_datafusion(op) else {
+        return SimplePredicate::AlwaysTrue;
+    };
 
-    // Try column = literal pattern
+    // column <op> literal
     if let (Expr::Column(col), Expr::Literal(lit, _)) = (left, right) {
         return convert_column_literal_compare(&col.name, compare_op, lit);
     }
 
-    // Try literal = column pattern (reverse)
+    // literal <op> column (reverse the operator)
     if let (Expr::Literal(lit, _), Expr::Column(col)) = (left, right) {
-        // Reverse the operator for symmetric comparisons
         let reversed_op = match compare_op {
             CompareOp::Lt => CompareOp::Gt,
             CompareOp::LtEq => CompareOp::GtEq,
@@ -300,77 +233,43 @@ fn convert_binary_expr(left: &Expr, op: &Operator, right: &Expr) -> Option<Simpl
         return convert_column_literal_compare(&col.name, reversed_op, lit);
     }
 
-    // Can't push down this expression
-    Some(SimplePredicate::AlwaysTrue)
+    SimplePredicate::AlwaysTrue
 }
 
-/// Convert a column = literal comparison to a simple predicate.
+/// Convert a column-vs-literal comparison to a simple predicate.
 fn convert_column_literal_compare(
     column: &str,
     op: CompareOp,
     literal: &ScalarValue,
-) -> Option<SimplePredicate> {
-    // Handle protocol column specially
-    if column == "protocol" {
-        if let ScalarValue::Utf8(Some(s)) = literal {
-            if op == CompareOp::Eq {
-                return Some(SimplePredicate::ProtocolEquals { value: s.clone() });
-            }
-        }
-        return Some(SimplePredicate::AlwaysTrue);
-    }
-
-    // Handle string columns
+) -> SimplePredicate {
     match literal {
         ScalarValue::Utf8(Some(s)) | ScalarValue::LargeUtf8(Some(s)) => {
-            Some(SimplePredicate::StringCompare {
+            SimplePredicate::StringCompare {
                 field: column.to_string(),
                 op,
                 value: s.clone(),
-            })
+            }
         }
-        // Handle integer types
-        ScalarValue::Int8(Some(v)) => Some(SimplePredicate::IntCompare {
-            field: column.to_string(),
-            op,
-            value: *v as i64,
-        }),
-        ScalarValue::Int16(Some(v)) => Some(SimplePredicate::IntCompare {
-            field: column.to_string(),
-            op,
-            value: *v as i64,
-        }),
-        ScalarValue::Int32(Some(v)) => Some(SimplePredicate::IntCompare {
-            field: column.to_string(),
-            op,
-            value: *v as i64,
-        }),
-        ScalarValue::Int64(Some(v)) => Some(SimplePredicate::IntCompare {
-            field: column.to_string(),
-            op,
-            value: *v,
-        }),
-        ScalarValue::UInt8(Some(v)) => Some(SimplePredicate::IntCompare {
-            field: column.to_string(),
-            op,
-            value: *v as i64,
-        }),
-        ScalarValue::UInt16(Some(v)) => Some(SimplePredicate::IntCompare {
-            field: column.to_string(),
-            op,
-            value: *v as i64,
-        }),
-        ScalarValue::UInt32(Some(v)) => Some(SimplePredicate::IntCompare {
-            field: column.to_string(),
-            op,
-            value: *v as i64,
-        }),
-        ScalarValue::UInt64(Some(v)) => Some(SimplePredicate::IntCompare {
-            field: column.to_string(),
-            op,
-            value: *v as i64,
-        }),
-        _ => Some(SimplePredicate::AlwaysTrue),
+        ScalarValue::Int8(Some(v)) => int_compare(column, op, *v as i64),
+        ScalarValue::Int16(Some(v)) => int_compare(column, op, *v as i64),
+        ScalarValue::Int32(Some(v)) => int_compare(column, op, *v as i64),
+        ScalarValue::Int64(Some(v)) => int_compare(column, op, *v),
+        ScalarValue::UInt8(Some(v)) => int_compare(column, op, *v as i64),
+        ScalarValue::UInt16(Some(v)) => int_compare(column, op, *v as i64),
+        ScalarValue::UInt32(Some(v)) => int_compare(column, op, *v as i64),
+        ScalarValue::UInt64(Some(v)) => match i64::try_from(*v) {
+            Ok(v) => int_compare(column, op, v),
+            Err(_) => SimplePredicate::AlwaysTrue,
+        },
+        _ => SimplePredicate::AlwaysTrue,
+    }
+}
+
+fn int_compare(column: &str, op: CompareOp, value: i64) -> SimplePredicate {
+    SimplePredicate::IntCompare {
+        field: column.to_string(),
+        op,
+        value,
     }
 }
 
@@ -382,181 +281,125 @@ mod tests {
     use pcapsql_core::TunnelType;
     use smallvec::SmallVec;
 
-    fn create_tcp_parsed() -> Vec<(&'static str, ParseResult<'static>)> {
+    fn tcp_result() -> ParseResult<'static> {
+        let mut fields = SmallVec::new();
+        fields.push(("src_port", FieldValue::UInt16(12345)));
+        fields.push(("dst_port", FieldValue::UInt16(80)));
+        fields.push(("flags", FieldValue::UInt16(0x02)));
+        ParseResult {
+            fields,
+            remaining: &[],
+            child_hints: SmallVec::new(),
+            error: None,
+            encap_depth: 0,
+            tunnel_type: TunnelType::None,
+            tunnel_id: None,
+        }
+    }
+
+    fn ipv4_result() -> ParseResult<'static> {
         use std::net::{IpAddr, Ipv4Addr};
-
-        let mut eth_fields = SmallVec::new();
-        eth_fields.push((
-            "src_mac",
-            FieldValue::MacAddr([0x00, 0x11, 0x22, 0x33, 0x44, 0x55]),
-        ));
-        eth_fields.push((
-            "dst_mac",
-            FieldValue::MacAddr([0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
-        ));
-        eth_fields.push(("ethertype", FieldValue::UInt16(0x0800)));
-
-        let mut ipv4_fields = SmallVec::new();
-        ipv4_fields.push((
+        let mut fields = SmallVec::new();
+        fields.push((
             "src_ip",
             FieldValue::IpAddr(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))),
         ));
-        ipv4_fields.push((
-            "dst_ip",
-            FieldValue::IpAddr(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2))),
-        ));
-        ipv4_fields.push(("ttl", FieldValue::UInt8(64)));
-        ipv4_fields.push(("protocol", FieldValue::UInt8(6)));
-
-        let mut tcp_fields = SmallVec::new();
-        tcp_fields.push(("src_port", FieldValue::UInt16(12345)));
-        tcp_fields.push(("dst_port", FieldValue::UInt16(80)));
-        tcp_fields.push(("flags", FieldValue::UInt16(0x02)));
-
-        vec![
-            (
-                "ethernet",
-                ParseResult {
-                    fields: eth_fields,
-                    remaining: &[],
-                    child_hints: SmallVec::new(),
-                    error: None,
-                    encap_depth: 0,
-                    tunnel_type: TunnelType::None,
-                    tunnel_id: None,
-                },
-            ),
-            (
-                "ipv4",
-                ParseResult {
-                    fields: ipv4_fields,
-                    remaining: &[],
-                    child_hints: SmallVec::new(),
-                    error: None,
-                    encap_depth: 0,
-                    tunnel_type: TunnelType::None,
-                    tunnel_id: None,
-                },
-            ),
-            (
-                "tcp",
-                ParseResult {
-                    fields: tcp_fields,
-                    remaining: &[],
-                    child_hints: SmallVec::new(),
-                    error: None,
-                    encap_depth: 0,
-                    tunnel_type: TunnelType::None,
-                    tunnel_id: None,
-                },
-            ),
-        ]
+        fields.push(("ttl", FieldValue::UInt8(64)));
+        ParseResult {
+            fields,
+            remaining: &[],
+            child_hints: SmallVec::new(),
+            error: None,
+            encap_depth: 0,
+            tunnel_type: TunnelType::None,
+            tunnel_id: None,
+        }
     }
 
     #[test]
-    fn test_protocol_equals() {
-        let parsed = create_tcp_parsed();
-
-        let pred = SimplePredicate::ProtocolEquals {
-            value: "TCP".to_string(),
-        };
-        assert!(pred.matches(&parsed));
-
-        let pred = SimplePredicate::ProtocolEquals {
-            value: "UDP".to_string(),
-        };
-        assert!(!pred.matches(&parsed));
+    fn test_int_compare_positive_and_negative() {
+        let result = tcp_result();
+        let keep = FilterEvaluator::try_from_exprs(&[col("dst_port").eq(lit(80i32))]).unwrap();
+        assert!(keep.matches_result(&result));
+        let drop = FilterEvaluator::try_from_exprs(&[col("dst_port").eq(lit(443i32))]).unwrap();
+        assert!(!drop.matches_result(&result));
     }
 
     #[test]
-    fn test_port_compare() {
-        let parsed = create_tcp_parsed();
-
-        let pred = SimplePredicate::IntCompare {
-            field: "dst_port".to_string(),
-            op: CompareOp::Eq,
-            value: 80,
-        };
-        assert!(pred.matches(&parsed));
-
-        let pred = SimplePredicate::IntCompare {
-            field: "dst_port".to_string(),
-            op: CompareOp::Gt,
-            value: 443,
-        };
-        assert!(!pred.matches(&parsed));
+    fn test_missing_field_keeps_row() {
+        // mss is absent: SQL NULL semantics belong to DataFusion, the
+        // parse-time filter must keep the row.
+        let result = tcp_result();
+        let f = FilterEvaluator::try_from_exprs(&[col("mss").eq(lit(1460i32))]).unwrap();
+        assert!(f.matches_result(&result));
+        let f = FilterEvaluator::try_from_exprs(&[col("mss").not_eq(lit(1460i32))]).unwrap();
+        assert!(f.matches_result(&result));
     }
 
     #[test]
-    fn test_ip_compare() {
-        let parsed = create_tcp_parsed();
-
-        let pred = SimplePredicate::StringCompare {
-            field: "src_ip".to_string(),
-            op: CompareOp::Eq,
-            value: "192.168.1.1".to_string(),
-        };
-        assert!(pred.matches(&parsed));
-
-        let pred = SimplePredicate::StringCompare {
+    fn test_ipv4_compares_as_u32_column_value() {
+        let result = ipv4_result();
+        let ip_as_u32 = u32::from(std::net::Ipv4Addr::new(192, 168, 1, 1)) as i64;
+        let keep = FilterEvaluator::try_from_exprs(&[col("src_ip").eq(lit(ip_as_u32))]).unwrap();
+        assert!(keep.matches_result(&result));
+        let drop =
+            FilterEvaluator::try_from_exprs(&[col("src_ip").eq(lit(ip_as_u32 + 1))]).unwrap();
+        assert!(!drop.matches_result(&result));
+        // A string literal against the UInt32 ip column is not confidently
+        // comparable at parse time: keep.
+        let keep = SimplePredicate::StringCompare {
             field: "src_ip".to_string(),
             op: CompareOp::Eq,
             value: "10.0.0.1".to_string(),
         };
-        assert!(!pred.matches(&parsed));
+        assert!(keep.matches_result(&result));
     }
 
     #[test]
-    fn test_and_predicate() {
-        let parsed = create_tcp_parsed();
+    fn test_and_combines() {
+        let result = tcp_result();
+        let f = FilterEvaluator::try_from_exprs(&[
+            col("dst_port").eq(lit(80i32)),
+            col("src_port").gt(lit(10000i32)),
+        ])
+        .unwrap();
+        assert!(f.matches_result(&result));
 
-        let pred = SimplePredicate::And(
-            Box::new(SimplePredicate::ProtocolEquals {
-                value: "TCP".to_string(),
-            }),
-            Box::new(SimplePredicate::IntCompare {
-                field: "dst_port".to_string(),
-                op: CompareOp::Eq,
-                value: 80,
-            }),
-        );
-        assert!(pred.matches(&parsed));
-
-        let pred = SimplePredicate::And(
-            Box::new(SimplePredicate::ProtocolEquals {
-                value: "UDP".to_string(),
-            }),
-            Box::new(SimplePredicate::IntCompare {
-                field: "dst_port".to_string(),
-                op: CompareOp::Eq,
-                value: 80,
-            }),
-        );
-        assert!(!pred.matches(&parsed));
+        let f = FilterEvaluator::try_from_exprs(&[
+            col("dst_port").eq(lit(80i32)),
+            col("src_port").gt(lit(60000i32)),
+        ])
+        .unwrap();
+        assert!(!f.matches_result(&result));
     }
 
     #[test]
-    fn test_from_datafusion_expr() {
-        // protocol = 'TCP'
-        let expr = col("protocol").eq(lit("TCP"));
-        let evaluator = FilterEvaluator::try_from_exprs(&[expr]).unwrap();
-        let parsed = create_tcp_parsed();
-        assert!(evaluator.matches(&parsed));
+    fn test_or_and_unsupported_keep_rows() {
+        let result = tcp_result();
+        // OR converts to AlwaysTrue → no evaluator at all.
+        let or_expr = col("dst_port")
+            .eq(lit(80i32))
+            .or(col("dst_port").eq(lit(443i32)));
+        assert!(FilterEvaluator::try_from_exprs(std::slice::from_ref(&or_expr)).is_none());
+        assert!(!FilterEvaluator::expr_is_pushable(&or_expr));
 
-        // dst_port = 80
-        let expr = col("dst_port").eq(lit(80i32));
-        let evaluator = FilterEvaluator::try_from_exprs(&[expr]).unwrap();
-        assert!(evaluator.matches(&parsed));
+        // Mixed: the convertible conjunct still applies; the rest keeps rows.
+        let f =
+            FilterEvaluator::try_from_exprs(&[or_expr, col("dst_port").eq(lit(443i32))]).unwrap();
+        assert!(!f.matches_result(&result));
+    }
 
-        // dst_port = 443
-        let expr = col("dst_port").eq(lit(443i32));
-        let evaluator = FilterEvaluator::try_from_exprs(&[expr]).unwrap();
-        assert!(!evaluator.matches(&parsed));
+    #[test]
+    fn test_reversed_literal_column() {
+        let result = tcp_result();
+        // 100 > src_port  ⇒  src_port < 100 (12345 ⇒ false)
+        let expr = lit(100i32).gt(col("src_port"));
+        let f = FilterEvaluator::try_from_exprs(&[expr]).unwrap();
+        assert!(!f.matches_result(&result));
     }
 
     #[test]
     fn test_empty_exprs() {
-        let evaluator = FilterEvaluator::try_from_exprs(&[]);
-        assert!(evaluator.is_none());
+        assert!(FilterEvaluator::try_from_exprs(&[]).is_none());
     }
 }

--- a/pcapsql-datafusion/src/query/mod.rs
+++ b/pcapsql-datafusion/src/query/mod.rs
@@ -32,17 +32,24 @@ pub mod views;
 pub use arrow_schema::{descriptors_to_arrow_schema, protocol_to_arrow_schema, to_arrow_field};
 pub use builders::NormalizedBatchSet;
 pub use filter::FilterEvaluator;
-pub use providers::{ProgressFn, ProtocolScanExec, ProtocolTableProvider, SharedParseState};
+pub use providers::{
+    ParseStats, ParseSubscription, ProgressFn, ProtocolScanExec, ProtocolTableProvider,
+    TableSubscription,
+};
+pub use udf::CaptureTimeRange;
 
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use arrow::array::RecordBatch;
+use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::config::ConfigOptions;
+use datafusion::logical_expr::{Expr, LogicalPlan};
 use datafusion::prelude::*;
 
 use crate::error::{Error, QueryError};
-use crate::query::providers::run_shared_parse;
+use crate::query::providers::{run_shared_parse, EngineTables, SharedParseState, TableData};
 use pcapsql_core::{
     default_registry, FilePacketSource, KeyLog, MmapPacketSource, ProtocolRegistry,
     SeekablePacketSource,
@@ -61,11 +68,12 @@ fn default_target_partitions() -> usize {
 }
 
 /// Configure DataFusion for SortMergeJoin on frame_number-sorted streams.
-fn create_session_context() -> SessionContext {
+fn create_session_context(target_partitions: usize) -> SessionContext {
     let mut config = ConfigOptions::default();
 
-    // SortMergeJoin requires target_partitions > 1
-    config.execution.target_partitions = 2;
+    // SortMergeJoin requires target_partitions > 1; otherwise scale with the
+    // parse parallelism so execution is not throttled below it.
+    config.execution.target_partitions = target_partitions.max(2);
     // Use our declared sort order (by frame_number)
     config.optimizer.prefer_existing_sort = true;
     // Prefer SortMergeJoin - works better with our sorted streams
@@ -95,11 +103,27 @@ pub struct CloudSourceOptions {
     pub chunk_size: Option<usize>,
 }
 
+/// What the engine retains between queries.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RetentionPolicy {
+    /// Retain nothing: each query parses exactly what it needs (columns,
+    /// parse-time predicates, row caps) and the result is dropped after
+    /// execution. The right policy for one-shot queries.
+    None,
+    /// Cache each touched table (full columns, unfiltered) on first use, so
+    /// later queries over the same tables parse nothing. The right policy
+    /// for the REPL. Caching full columns keeps reuse sound for any later
+    /// query shape.
+    CacheOnTouch,
+}
+
 /// Construction options for [`QueryEngine::open`].
 #[derive(Clone)]
 pub struct EngineOptions {
     /// Packets per RecordBatch.
     pub batch_size: usize,
+    /// What to retain between queries (see [`RetentionPolicy`]).
+    pub retention: RetentionPolicy,
     /// Partition count for the parallel parse pass
     /// (`None` = available parallelism, clamped to 1..=16).
     pub target_partitions: Option<usize>,
@@ -120,6 +144,7 @@ impl Default for EngineOptions {
     fn default() -> Self {
         Self {
             batch_size: 10_000,
+            retention: RetentionPolicy::CacheOnTouch,
             target_partitions: None,
             keylog: None,
             mmap: true,
@@ -133,20 +158,89 @@ impl Default for EngineOptions {
 /// Query engine for PCAP files.
 pub struct QueryEngine {
     ctx: SessionContext,
-    registry: ProtocolRegistry,
-    /// Result of the single shared parse pass every table serves from.
-    shared: Arc<SharedParseState>,
+    registry: Arc<ProtocolRegistry>,
+    /// Tables materialized for the current query (or cached, per retention).
+    tables: Arc<EngineTables>,
+    /// Capture time range, widened by every parse pass (drives time UDFs).
+    time_range: Arc<CaptureTimeRange>,
+    retention: RetentionPolicy,
+    /// Runs one scoped parse pass over the engine's source.
+    parse_fn: ParseFn,
+    /// Instrumentation for the most recent query.
+    last_stats: RwLock<ParseStats>,
+    /// Table names this engine registered (the harvest universe).
+    known_tables: HashSet<String>,
+}
+
+/// Type-erased scoped parse over the engine's source.
+type ParseFn = Box<dyn Fn(&ParseSubscription) -> Result<SharedParseState, Error> + Send + Sync>;
+
+/// What one query needs from one table, harvested from its optimized plan.
+#[derive(Debug, Default)]
+struct TableNeeds {
+    /// Referenced columns (`None` = all, e.g. `SELECT *`).
+    columns: Option<HashSet<String>>,
+    /// Filters pushed into the scan (`Inexact`; DataFusion re-checks).
+    filters: Vec<Expr>,
+    /// Pushed-down LIMIT.
+    fetch: Option<usize>,
+    /// Number of scans of this table in the plan (self-joins disable
+    /// per-scan scoping so one materialization can serve every scan).
+    scan_count: usize,
+}
+
+/// Walk an optimized plan and collect per-table needs for our tables.
+fn harvest_table_needs(
+    plan: &LogicalPlan,
+    known_tables: &HashSet<String>,
+) -> Result<HashMap<String, TableNeeds>, Error> {
+    let mut needs: HashMap<String, TableNeeds> = HashMap::new();
+    plan.apply_with_subqueries(|node| {
+        if let LogicalPlan::TableScan(scan) = node {
+            let name = scan.table_name.table();
+            if known_tables.contains(name) {
+                let columns: Option<HashSet<String>> = scan.projection.as_ref().map(|indices| {
+                    let schema = scan.source.schema();
+                    indices
+                        .iter()
+                        .map(|&i| schema.field(i).name().clone())
+                        .collect()
+                });
+                let entry = needs.entry(name.to_string()).or_default();
+                entry.scan_count += 1;
+                if entry.scan_count == 1 {
+                    entry.columns = columns;
+                    entry.filters = scan.filters.clone();
+                    entry.fetch = scan.fetch;
+                } else {
+                    // Multiple scans of one table: one materialization must
+                    // serve them all — union columns, drop predicates/caps.
+                    entry.columns = match (entry.columns.take(), columns) {
+                        (Some(mut a), Some(b)) => {
+                            a.extend(b);
+                            Some(a)
+                        }
+                        _ => None,
+                    };
+                    entry.filters.clear();
+                    entry.fetch = None;
+                }
+            }
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .map_err(|e| Error::Query(QueryError::Execution(e.to_string())))?;
+    Ok(needs)
 }
 
 impl QueryEngine {
     /// Open a capture and build the engine.
     ///
     /// The single constructor: local files (memory-mapped by default, with a
-    /// buffered-file fallback) and cloud URLs funnel into the same shared
-    /// parse pass, parallel across partitions for seekable sources. With a
-    /// [`EngineOptions::keylog`], an additional sequential stream pass
-    /// populates the decrypted `http2` table (folded into the main pass by
-    /// migration phase P4).
+    /// buffered-file fallback) and cloud URLs are served by the same scoped
+    /// parse machinery. **No parsing happens here** — each query parses
+    /// exactly the tables (and columns/predicates/limits) it references, per
+    /// the engine's [`RetentionPolicy`].
     pub async fn open(spec: SourceSpec, opts: EngineOptions) -> Result<Self, Error> {
         match spec {
             SourceSpec::Path(path) => {
@@ -198,57 +292,45 @@ impl QueryEngine {
         }
     }
 
-    /// Build the engine over an opened source: ONE parse pass, fanned out to
-    /// all protocol tables, parallel across partitions.
+    /// Build the engine over an opened source: register providers, UDFs and
+    /// views, and capture the scoped-parse closure queries will drive.
     async fn build<S: SeekablePacketSource>(
         source: Arc<S>,
         opts: EngineOptions,
     ) -> Result<Self, Error> {
         let registry = Arc::new(default_registry());
-        let ctx = create_session_context();
-        udf::register_all_udfs(&ctx)?;
-
-        let target_partitions = opts
+        let parallelism = opts
             .target_partitions
             .unwrap_or_else(default_target_partitions);
+        let ctx = create_session_context(parallelism);
+        udf::register_all_udfs(&ctx)?;
 
-        let shared = Arc::new(run_shared_parse(
-            &source,
-            &registry,
-            opts.batch_size,
-            target_partitions,
-            opts.progress.clone(),
-        )?);
+        // Time UDFs read a shared range that parse passes widen.
+        let time_range = Arc::new(CaptureTimeRange::new());
+        udf::register_time_udfs(&ctx, time_range.clone())?;
 
-        if shared.total_frames() == 0 {
-            return Err(Error::Query(QueryError::Execution(
-                "No packets found in PCAP source".to_string(),
-            )));
-        }
-
-        // Timestamp range comes from the shared pass (no extra scan).
-        let (start_us, end_us) = shared.timestamp_range_us();
-        udf::register_time_udfs_eager(&ctx, start_us, end_us)?;
-
-        // One provider per table, all sharing the single parse result.
+        // One provider per table, all serving from the same engine state.
+        let engine_tables = Arc::new(EngineTables::new());
+        let mut known_tables = HashSet::new();
         for table_name in tables::all_table_names() {
             let schema = Arc::new(tables::get_table_schema(table_name).ok_or_else(|| {
                 Error::Query(QueryError::Execution(format!(
                     "Unknown table: {table_name}"
                 )))
             })?);
-            let provider = providers::ProtocolTableProvider::shared(
+            let provider = providers::ProtocolTableProvider::new(
                 table_name.to_string(),
                 schema,
-                shared.clone(),
+                engine_tables.clone(),
             );
             ctx.register_table(table_name, Arc::new(provider))
                 .map_err(|e| Error::Query(QueryError::Execution(e.to_string())))?;
+            known_tables.insert(table_name.to_string());
         }
 
         // With a keylog, a sequential stream pass (TCP reassembly + TLS
-        // decryption + HTTP/2) replaces the empty http2 table. Migration
-        // phase P4 folds this second pass into the shared one.
+        // decryption + HTTP/2) pins the decrypted http2 table. Migration
+        // phase P4 folds this second pass into the scoped parse.
         if let Some(keylog) = opts.keylog.clone() {
             let mut stream_builder = stream_tables::StreamTableBuilder::new(Some(keylog));
             let mut reader = source.sequential_reader()?;
@@ -256,65 +338,158 @@ impl QueryEngine {
             let http2_batches = stream_builder.http2_batches(opts.batch_size)?;
             if !http2_batches.is_empty() {
                 let schema = http2_batches[0].schema();
-                let provider = providers::ProtocolTableProvider::in_memory(
+                engine_tables.pin(
                     "http2".to_string(),
-                    schema,
-                    vec![http2_batches],
+                    Arc::new(TableData {
+                        schema,
+                        partitions: vec![http2_batches],
+                    }),
                 );
-                ctx.deregister_table("http2")
-                    .map_err(|e| Error::Query(QueryError::Execution(e.to_string())))?;
-                ctx.register_table("http2", Arc::new(provider))
-                    .map_err(|e| Error::Query(QueryError::Execution(e.to_string())))?;
             }
         }
 
         Self::register_cross_layer_views(&ctx).await?;
 
+        let parse_fn: ParseFn = {
+            let registry = registry.clone();
+            let batch_size = opts.batch_size;
+            let progress = opts.progress.clone();
+            Box::new(move |subscription: &ParseSubscription| {
+                run_shared_parse(
+                    &source,
+                    &registry,
+                    batch_size,
+                    parallelism,
+                    progress.clone(),
+                    subscription,
+                )
+            })
+        };
+
         Ok(Self {
             ctx,
-            registry: (*registry).clone(),
-            shared,
+            registry,
+            tables: engine_tables,
+            time_range,
+            retention: opts.retention,
+            parse_fn,
+            last_stats: RwLock::new(ParseStats::default()),
+            known_tables,
         })
     }
 
     /// Execute a SQL query and return results.
+    ///
+    /// Plans first, harvests the optimized plan's table needs, runs one
+    /// scoped parse pass covering them (subject to the retention policy's
+    /// cache), then executes. This is THE query path: queries issued
+    /// directly against [`Self::context`] bypass the parse and will fail
+    /// with "table was not prepared".
     pub async fn query(&self, sql: &str) -> Result<Vec<RecordBatch>, Error> {
-        let df = self
-            .ctx
-            .sql(sql)
+        let state = self.ctx.state();
+        let plan = state
+            .create_logical_plan(sql)
             .await
             .map_err(|e| Error::Query(QueryError::from(e)))?;
-
-        let batches = df
-            .collect()
-            .await
+        let optimized = state
+            .optimize(&plan)
             .map_err(|e| Error::Query(QueryError::from(e)))?;
 
-        Ok(batches)
+        let needs = harvest_table_needs(&optimized, &self.known_tables)?;
+        let stats = self.prepare_tables(needs)?;
+        *self.last_stats.write().expect("stats lock poisoned") = stats;
+
+        let result = async {
+            let df = self
+                .ctx
+                .execute_logical_plan(optimized)
+                .await
+                .map_err(|e| Error::Query(QueryError::from(e)))?;
+            df.collect()
+                .await
+                .map_err(|e| Error::Query(QueryError::from(e)))
+        }
+        .await;
+
+        if self.retention == RetentionPolicy::None {
+            self.tables.clear();
+        }
+
+        result
+    }
+
+    /// Run the scoped parse pass covering `needs`, honoring the retention
+    /// policy. Returns the pass statistics (zeroed when fully cache-served).
+    fn prepare_tables(&self, needs: HashMap<String, TableNeeds>) -> Result<ParseStats, Error> {
+        let mut subscription = ParseSubscription::default();
+
+        match self.retention {
+            RetentionPolicy::CacheOnTouch => {
+                // Cache entries are full-column and unfiltered, so they can
+                // serve any later query; only parse what's missing.
+                for name in needs.into_keys() {
+                    if !self.tables.contains(&name) {
+                        subscription
+                            .tables
+                            .insert(name, TableSubscription::default());
+                    }
+                }
+            }
+            RetentionPolicy::None => {
+                for (name, table_needs) in needs {
+                    if self.tables.contains(&name) {
+                        continue; // pinned (e.g. keylog http2)
+                    }
+                    let multi_scan = table_needs.scan_count > 1;
+                    let predicate = if multi_scan || name == "frames" {
+                        None
+                    } else {
+                        FilterEvaluator::try_from_exprs(&table_needs.filters)
+                    };
+                    subscription.tables.insert(
+                        name,
+                        TableSubscription {
+                            columns: if multi_scan {
+                                None
+                            } else {
+                                table_needs.columns
+                            },
+                            predicate,
+                            fetch: if multi_scan { None } else { table_needs.fetch },
+                        },
+                    );
+                }
+            }
+        }
+
+        if subscription.tables.is_empty() {
+            return Ok(ParseStats::default());
+        }
+
+        let parsed = (self.parse_fn)(&subscription)?;
+        let (tables, stats) = parsed.into_tables();
+        if stats.packets_scanned > 0 {
+            self.time_range.record(stats.start_ts_us, stats.end_ts_us);
+        }
+        self.tables.install(tables);
+        Ok(stats)
+    }
+
+    /// Instrumentation for the most recent query: parse passes (0 when fully
+    /// served from cache, 1 otherwise — the shared-parse invariant), packets
+    /// scanned, partitions, and rows built per table.
+    pub fn last_parse_stats(&self) -> ParseStats {
+        self.last_stats.read().expect("stats lock poisoned").clone()
     }
 
     /// Get the protocol registry.
     pub fn registry(&self) -> &ProtocolRegistry {
-        &self.registry
+        self.registry.as_ref()
     }
 
     /// Get the session context for advanced usage.
     pub fn context(&self) -> &SessionContext {
         &self.ctx
-    }
-
-    /// Number of parse passes performed over the source.
-    ///
-    /// Always `1` regardless of how many protocol tables a query touches —
-    /// the instrumentation behind the shared-parse invariant.
-    pub fn parse_pass_count(&self) -> usize {
-        self.shared.parse_passes()
-    }
-
-    /// Number of partitions the shared parse pass used (1 if non-partitioned or
-    /// in-memory mode).
-    pub fn partition_count(&self) -> usize {
-        self.shared.num_partitions()
     }
 
     /// Register cross-layer views that JOIN normalized protocol tables.

--- a/pcapsql-datafusion/src/query/providers/mod.rs
+++ b/pcapsql-datafusion/src/query/providers/mod.rs
@@ -22,6 +22,9 @@ mod protocol_provider;
 mod scan_exec;
 mod shared;
 
-pub use protocol_provider::ProtocolTableProvider;
+pub use protocol_provider::{EngineTables, ProtocolTableProvider};
 pub use scan_exec::ProtocolScanExec;
-pub use shared::{run_shared_parse, ProgressFn, SharedParseState};
+pub use shared::{
+    run_shared_parse, ParseStats, ParseSubscription, ProgressFn, SharedParseState, TableData,
+    TableSubscription,
+};

--- a/pcapsql-datafusion/src/query/providers/protocol_provider.rs
+++ b/pcapsql-datafusion/src/query/providers/protocol_provider.rs
@@ -1,65 +1,108 @@
-//! Protocol table provider backed by the shared parse pass.
+//! Protocol table provider backed by the engine's per-query parse state.
+//!
+//! Every provider holds the same [`EngineTables`] handle. `QueryEngine::query`
+//! installs each query's scoped parse result (or cache entries) before
+//! executing the physical plan, and the provider serves its table from that
+//! state — so a query touching N tables still parses the capture exactly
+//! once, scoped to what the query needs.
 
 use std::any::Any;
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use arrow::datatypes::SchemaRef;
-use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
+use datafusion::common::DataFusionError;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::Result as DFResult;
-use datafusion::logical_expr::Expr;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use datafusion::physical_plan::ExecutionPlan;
 
-use super::shared::SharedParseState;
+use super::shared::TableData;
 use super::ProtocolScanExec;
+use crate::query::filter::FilterEvaluator;
 
-/// Table provider for a single protocol table.
+/// The tables currently materialized for query execution.
 ///
-/// All providers for a query share one [`SharedParseState`] (the result of the
-/// single parse pass), so a query touching N tables parses the capture once.
-pub struct ProtocolTableProvider {
-    table_name: String,
-    schema: SchemaRef,
-    /// Shared parse result, or pre-loaded batches for the in-memory path.
-    source: TableSource,
+/// - `current` holds the per-query scoped parse result
+///   (`RetentionPolicy::None`, cleared after each query) or the accumulated
+///   cache (`RetentionPolicy::CacheOnTouch`).
+/// - `pinned` holds tables installed once at engine open and never cleared
+///   (the keylog-decrypted `http2` table, until migration phase P4 folds the
+///   stream pass into the shared parse).
+#[derive(Debug, Default)]
+pub struct EngineTables {
+    current: RwLock<HashMap<String, Arc<TableData>>>,
+    pinned: RwLock<HashMap<String, Arc<TableData>>>,
 }
 
-enum TableSource {
-    /// Slice of the shared parse pass.
-    Shared(Arc<SharedParseState>),
-    /// Pre-loaded batches (used for empty tables / direct registration).
-    InMemory(Vec<Vec<RecordBatch>>),
+impl EngineTables {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Install (or replace) table entries for the current query / cache.
+    pub fn install(&self, tables: HashMap<String, Arc<TableData>>) {
+        self.current
+            .write()
+            .expect("EngineTables lock poisoned")
+            .extend(tables);
+    }
+
+    /// Pin a table for the lifetime of the engine (survives `clear`).
+    pub fn pin(&self, name: String, data: Arc<TableData>) {
+        self.pinned
+            .write()
+            .expect("EngineTables lock poisoned")
+            .insert(name, data);
+    }
+
+    /// Drop all non-pinned entries (`RetentionPolicy::None`, post-query).
+    pub fn clear(&self) {
+        self.current
+            .write()
+            .expect("EngineTables lock poisoned")
+            .clear();
+    }
+
+    /// Fetch a table's data (pinned entries win).
+    pub fn get(&self, name: &str) -> Option<Arc<TableData>> {
+        if let Some(data) = self
+            .pinned
+            .read()
+            .expect("EngineTables lock poisoned")
+            .get(name)
+        {
+            return Some(data.clone());
+        }
+        self.current
+            .read()
+            .expect("EngineTables lock poisoned")
+            .get(name)
+            .cloned()
+    }
+
+    /// Whether the table is already materialized (pinned or current).
+    pub fn contains(&self, name: &str) -> bool {
+        self.get(name).is_some()
+    }
+}
+
+/// Table provider for a single protocol table, serving from [`EngineTables`].
+pub struct ProtocolTableProvider {
+    table_name: String,
+    /// The table's full schema (planning surface; data may be a subset).
+    schema: SchemaRef,
+    tables: Arc<EngineTables>,
 }
 
 impl ProtocolTableProvider {
-    /// Create a provider that draws this table's batches from the shared parse.
-    pub fn shared(table_name: String, schema: SchemaRef, state: Arc<SharedParseState>) -> Self {
+    pub fn new(table_name: String, schema: SchemaRef, tables: Arc<EngineTables>) -> Self {
         Self {
             table_name,
             schema,
-            source: TableSource::Shared(state),
-        }
-    }
-
-    /// Create a provider over pre-loaded per-partition batches.
-    pub fn in_memory(
-        table_name: String,
-        schema: SchemaRef,
-        partitions: Vec<Vec<RecordBatch>>,
-    ) -> Self {
-        Self {
-            table_name,
-            schema,
-            source: TableSource::InMemory(partitions),
-        }
-    }
-
-    fn partitions(&self) -> Vec<Vec<RecordBatch>> {
-        match &self.source {
-            TableSource::Shared(state) => state.table_partitions(&self.table_name),
-            TableSource::InMemory(parts) => parts.clone(),
+            tables,
         }
     }
 }
@@ -78,6 +121,26 @@ impl TableProvider for ProtocolTableProvider {
         TableType::Base
     }
 
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DFResult<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|expr| {
+                // frames columns are packet metadata, not parse fields — the
+                // parse-time evaluator cannot see them.
+                if self.table_name != "frames" && FilterEvaluator::expr_is_pushable(expr) {
+                    // Inexact: rows may be pre-dropped at parse time;
+                    // DataFusion re-applies the filter to whatever is kept.
+                    TableProviderFilterPushDown::Inexact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
     async fn scan(
         &self,
         _state: &dyn Session,
@@ -85,12 +148,49 @@ impl TableProvider for ProtocolTableProvider {
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        let partitions = Arc::new(self.partitions());
+        let data = self.tables.get(&self.table_name).ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "table '{}' was not prepared for this query; \
+                 run queries through QueryEngine::query",
+                self.table_name
+            ))
+        })?;
+
+        // `projection` indexes the FULL table schema; the materialized data
+        // may be a column subset. Remap by field name into the data's schema.
+        let remapped: Option<Vec<usize>> = match projection {
+            Some(indices) => Some(
+                indices
+                    .iter()
+                    .map(|&i| {
+                        let name = self.schema.field(i).name();
+                        data.schema.index_of(name).map_err(|_| {
+                            DataFusionError::Execution(format!(
+                                "column '{}' of table '{}' was not materialized for this query",
+                                name, self.table_name
+                            ))
+                        })
+                    })
+                    .collect::<DFResult<Vec<usize>>>()?,
+            ),
+            None => {
+                // Full-schema scan: only valid when the data is full-width.
+                if data.schema.fields().len() != self.schema.fields().len() {
+                    return Err(DataFusionError::Execution(format!(
+                        "table '{}' was materialized with a column subset but \
+                         scanned without a projection",
+                        self.table_name
+                    )));
+                }
+                None
+            }
+        };
+
         Ok(Arc::new(ProtocolScanExec::new(
             self.table_name.clone(),
-            self.schema.clone(),
-            partitions,
-            projection.cloned(),
+            data.schema.clone(),
+            Arc::new(data.partitions.clone()),
+            remapped,
         )))
     }
 }
@@ -99,13 +199,6 @@ impl std::fmt::Debug for ProtocolTableProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProtocolTableProvider")
             .field("table_name", &self.table_name)
-            .field(
-                "mode",
-                &match &self.source {
-                    TableSource::Shared(_) => "Shared",
-                    TableSource::InMemory(_) => "InMemory",
-                },
-            )
             .finish()
     }
 }

--- a/pcapsql-datafusion/src/query/providers/scan_exec.rs
+++ b/pcapsql-datafusion/src/query/providers/scan_exec.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use arrow::compute::SortOptions;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
+use datafusion::common::stats::Precision;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::context::TaskContext;
 use datafusion::physical_expr::{EquivalenceProperties, PhysicalSortExpr};
@@ -19,7 +20,7 @@ use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
-    SendableRecordBatchStream,
+    SendableRecordBatchStream, Statistics,
 };
 use futures::stream;
 
@@ -127,6 +128,29 @@ impl ExecutionPlan for ProtocolScanExec {
             self.projected_schema.clone(),
             stream::iter(iter),
         )))
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> DFResult<Statistics> {
+        // Batches are already materialized: row counts are exact and free,
+        // which lets the optimizer order joins sensibly.
+        let rows: usize = match partition {
+            Some(i) => self
+                .partitions
+                .get(i)
+                .map(|p| p.iter().map(|b| b.num_rows()).sum())
+                .unwrap_or(0),
+            None => self
+                .partitions
+                .iter()
+                .flat_map(|p| p.iter())
+                .map(|b| b.num_rows())
+                .sum(),
+        };
+        Ok(Statistics {
+            num_rows: Precision::Exact(rows),
+            total_byte_size: Precision::Absent,
+            column_statistics: Statistics::unknown_column(&self.projected_schema),
+        })
     }
 }
 

--- a/pcapsql-datafusion/src/query/providers/shared.rs
+++ b/pcapsql-datafusion/src/query/providers/shared.rs
@@ -1,32 +1,32 @@
-//! Shared single-pass parse — the implementation of #6 and #9.
+//! The scoped, shared single-pass parse.
 //!
-//! A query touching N protocol tables must parse the capture **once**, not once
-//! per table. This module performs a single fan-out parse pass over the source,
-//! routing every packet into per-protocol Arrow builders ([`NormalizedBatchSet`])
-//! exactly as the in-memory path does, and memoizes the per-table batches so all
-//! table providers share them.
-//!
-//! For a [`SeekablePacketSource`] the single pass is split into partitions and
-//! parsed in parallel — one worker per partition, each owning its own reader and
-//! builders, with no shared mutable state to lock (mmap is the zero-cost case).
-//! The cost hint gates whether partitioning is worthwhile. Non-seekable sources
-//! degrade honestly to a single partition.
+//! A query touching N protocol tables parses the capture **once**, not once
+//! per table — and only as much of it as the query needs. The engine
+//! harvests each query's optimized plan into a [`ParseSubscription`]
+//! (which tables, which columns, parse-time predicates, row caps), and
+//! [`run_shared_parse`] performs one fan-out parse pass restricted to that
+//! subscription, in parallel across partitions for seekable sources.
 //!
 //! Partitions are range-partitioned by frame number and reassembled in frame
-//! order, so the result is identical to a single-partition parse — the property
-//! the partition-equivalence tests assert.
+//! order, so the result is identical to a single-partition parse — the
+//! property the partition-equivalence tests assert.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 
 use pcapsql_core::io::PacketRange;
-use pcapsql_core::{parse_packet, PacketReader, ProtocolRegistry, SeekablePacketSource};
+use pcapsql_core::{
+    parse_packet, PacketReader, ParseScope, ProtocolRegistry, SeekablePacketSource,
+};
 
 use crate::error::Error;
-use crate::query::builders::{NormalizedBatchSet, ProtocolBatches};
+use crate::query::builders::NormalizedBatchSet;
+use crate::query::filter::FilterEvaluator;
+use crate::query::tables;
 
 /// Minimum object size before a `Cheap`-seek source is partitioned.
 const CHEAP_MIN_BYTES: u64 = 4 * 1024 * 1024;
@@ -37,45 +37,140 @@ const RANGE_MIN_BYTES: u64 = 16 * 1024 * 1024;
 /// Progress callback: invoked with the cumulative packet count during parse.
 pub type ProgressFn = Arc<dyn Fn(u64) + Send + Sync>;
 
-/// Result of the shared parse pass: per-table batches grouped by partition.
+/// One table's subscription within a parse pass.
+#[derive(Clone, Debug, Default)]
+pub struct TableSubscription {
+    /// Columns to materialize (schema order is preserved); `None` = all.
+    pub columns: Option<HashSet<String>>,
+    /// Parse-time predicate (conservative; DataFusion re-checks).
+    pub predicate: Option<FilterEvaluator>,
+    /// Per-partition row cap from a pushed-down `LIMIT`.
+    pub fetch: Option<usize>,
+}
+
+/// What one parse pass materializes: the tables a query references, each
+/// with optional column scoping, predicates and row caps.
+#[derive(Clone, Debug, Default)]
+pub struct ParseSubscription {
+    pub tables: HashMap<String, TableSubscription>,
+}
+
+impl ParseSubscription {
+    /// Subscribe to the given tables with full columns, no predicates, no
+    /// caps (the cache-fill shape).
+    pub fn tables_full<I, S>(names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            tables: names
+                .into_iter()
+                .map(|n| (n.into(), TableSubscription::default()))
+                .collect(),
+        }
+    }
+
+    /// The protocol-level scope for this subscription: the subscribed
+    /// tables' protocols plus dependency closure, with per-protocol field
+    /// projections where columns are scoped.
+    fn parse_scope(&self, registry: &ProtocolRegistry) -> ParseScope {
+        let names: Vec<&str> = self.tables.keys().map(String::as_str).collect();
+        let mut scope = ParseScope::for_tables(&names, registry);
+
+        for (table, sub) in &self.tables {
+            if table == "frames" {
+                continue; // frames come from packet metadata, not parsing
+            }
+            if let Some(columns) = &sub.columns {
+                // Pseudo-columns are populated from ParseResult context, not
+                // extracted fields; they don't belong in the field projection.
+                let fields: HashSet<String> = columns
+                    .iter()
+                    .filter(|c| {
+                        !matches!(
+                            c.as_str(),
+                            "frame_number" | "encap_depth" | "tunnel_type" | "tunnel_id"
+                        )
+                    })
+                    .cloned()
+                    .collect();
+                scope = scope.with_projection(table.clone(), fields);
+            }
+        }
+        scope
+    }
+
+    /// The column-subset Arrow schema a subscribed table materializes.
+    pub fn table_schema(&self, table: &str) -> Option<SchemaRef> {
+        let full = tables::get_table_schema(table)?;
+        let sub = self.tables.get(table)?;
+        match &sub.columns {
+            None => Some(Arc::new(full)),
+            Some(cols) => {
+                let fields: Vec<_> = full
+                    .fields()
+                    .iter()
+                    .filter(|f| cols.contains(f.name().as_str()))
+                    .cloned()
+                    .collect();
+                Some(Arc::new(arrow::datatypes::Schema::new(fields)))
+            }
+        }
+    }
+}
+
+/// One table's materialized data: its (possibly column-subset) schema and
+/// per-partition batches in frame order.
+#[derive(Clone, Debug)]
+pub struct TableData {
+    pub schema: SchemaRef,
+    pub partitions: Vec<Vec<RecordBatch>>,
+}
+
+impl TableData {
+    /// Total rows across all partitions.
+    pub fn total_rows(&self) -> usize {
+        self.partitions
+            .iter()
+            .flat_map(|p| p.iter())
+            .map(|b| b.num_rows())
+            .sum()
+    }
+}
+
+/// Instrumentation for the most recent parse pass.
+#[derive(Clone, Debug, Default)]
+pub struct ParseStats {
+    /// Parse passes performed for the last query (0 = served from cache).
+    pub parse_passes: usize,
+    /// Packets read from the source during the pass.
+    pub packets_scanned: u64,
+    /// Partitions the pass was split into.
+    pub partitions: usize,
+    /// Rows materialized per table.
+    pub rows_built: HashMap<String, usize>,
+    /// Observed timestamp range (microseconds), valid when packets > 0.
+    pub start_ts_us: i64,
+    pub end_ts_us: i64,
+    /// False when a row cap (LIMIT) stopped the pass before end of input.
+    pub complete_scan: bool,
+}
+
+/// Result of one scoped parse pass.
 pub struct SharedParseState {
-    /// table name -> (one `Vec<RecordBatch>` per partition, in frame order).
-    tables: HashMap<String, Vec<Vec<RecordBatch>>>,
-    /// Number of partitions the pass used.
-    num_partitions: usize,
-    /// Number of parse passes performed (always 1; exposed for instrumentation).
-    parse_passes: usize,
-    /// Earliest / latest packet timestamp seen (microseconds), for time UDFs.
-    start_ts_us: i64,
-    end_ts_us: i64,
-    /// Total frames across all partitions.
-    total_frames: usize,
+    tables: HashMap<String, Arc<TableData>>,
+    stats: ParseStats,
 }
 
 impl SharedParseState {
-    /// Per-partition batches for a table (empty vec of partitions if unknown).
-    pub fn table_partitions(&self, table: &str) -> Vec<Vec<RecordBatch>> {
-        self.tables.get(table).cloned().unwrap_or_default()
+    /// Decompose into the materialized tables and the pass statistics.
+    pub fn into_tables(self) -> (HashMap<String, Arc<TableData>>, ParseStats) {
+        (self.tables, self.stats)
     }
 
-    /// Number of output partitions.
-    pub fn num_partitions(&self) -> usize {
-        self.num_partitions
-    }
-
-    /// Number of parse passes performed over the source (instrumentation for #6).
-    pub fn parse_passes(&self) -> usize {
-        self.parse_passes
-    }
-
-    /// (start, end) timestamps in microseconds.
-    pub fn timestamp_range_us(&self) -> (i64, i64) {
-        (self.start_ts_us, self.end_ts_us)
-    }
-
-    /// Total number of frames parsed.
-    pub fn total_frames(&self) -> usize {
-        self.total_frames
+    pub fn stats(&self) -> &ParseStats {
+        &self.stats
     }
 }
 
@@ -111,25 +206,39 @@ fn decide_ranges<S: SeekablePacketSource>(
     }
 }
 
-/// Parse a single partition into per-protocol batches, returning the batches and
-/// the (min, max) timestamps (microseconds) seen.
+/// Per-partition parse output.
+struct PartitionOutput {
+    batches: HashMap<String, Vec<RecordBatch>>,
+    min_us: i64,
+    max_us: i64,
+    packets: u64,
+    capped: bool,
+}
+
+/// Parse a single partition into per-table batches restricted to the
+/// subscription.
+#[allow(clippy::too_many_arguments)]
 fn parse_partition<S: SeekablePacketSource>(
     source: &S,
     registry: &ProtocolRegistry,
+    scope: &ParseScope,
+    subscription: &ParseSubscription,
     batch_size: usize,
     range: &PacketRange,
     single: bool,
     progress: Option<(&AtomicU64, &ProgressFn)>,
-) -> Result<(ProtocolBatches, i64, i64), Error> {
+) -> Result<PartitionOutput, Error> {
     let mut reader = if single {
         source.sequential_reader()?
     } else {
         source.reader_at(range)?
     };
 
-    let mut batch_set = NormalizedBatchSet::new(batch_size);
+    let mut batch_set = NormalizedBatchSet::new(batch_size, subscription)?;
     let mut min_us = i64::MAX;
     let mut max_us = i64::MIN;
+    let mut packets: u64 = 0;
+    let mut capped = false;
 
     loop {
         let processed = reader.process_packets(1024, |packet| {
@@ -141,59 +250,76 @@ fn parse_partition<S: SeekablePacketSource>(
                 max_us = us;
             }
             // Per-packet link type is correct even for PCAPNG multi-interface.
-            let parsed = parse_packet(registry, packet.link_type, packet.data);
+            let parsed = parse_packet(registry, packet.link_type, packet.data, scope);
             batch_set.add_packet_from_ref(packet, &parsed)?;
             Ok(())
         })?;
-        if processed == 0 {
-            break;
-        }
+        packets += processed as u64;
         if let Some((counter, cb)) = progress {
             let total = counter.fetch_add(processed as u64, Ordering::Relaxed) + processed as u64;
             cb(total);
         }
+        if processed == 0 {
+            break;
+        }
+        if batch_set.all_capped() {
+            capped = true;
+            break;
+        }
     }
 
-    Ok((batch_set.finish()?, min_us, max_us))
+    Ok(PartitionOutput {
+        batches: batch_set.finish()?,
+        min_us,
+        max_us,
+        packets,
+        capped,
+    })
 }
 
-/// Run the shared parse pass over a seekable source, fanning out to all protocol
-/// tables. Parses partitions in parallel when more than one.
+/// Run one scoped parse pass over a seekable source, fanning out to the
+/// subscribed tables. Parses partitions in parallel when more than one;
+/// each worker owns its reader and builders — no shared mutable state.
 pub fn run_shared_parse<S: SeekablePacketSource>(
     source: &Arc<S>,
     registry: &Arc<ProtocolRegistry>,
     batch_size: usize,
     target_partitions: usize,
     progress: Option<ProgressFn>,
+    subscription: &ParseSubscription,
 ) -> Result<SharedParseState, Error> {
+    let scope = subscription.parse_scope(registry);
     let ranges = decide_ranges(source.as_ref(), target_partitions)?;
     let single = ranges.len() == 1;
     let progress_count = AtomicU64::new(0);
 
-    // Parse each partition in its own worker. Each worker owns its reader and
-    // builders — no shared mutable state, so nothing to lock.
-    let results: Vec<Result<(ProtocolBatches, i64, i64), Error>> = if single {
+    let results: Vec<Result<PartitionOutput, Error>> = if single {
         vec![parse_partition(
             source.as_ref(),
             registry,
+            &scope,
+            subscription,
             batch_size,
             &ranges[0],
             true,
             progress.as_ref().map(|cb| (&progress_count, cb)),
         )]
     } else {
-        std::thread::scope(|scope| {
+        std::thread::scope(|thread_scope| {
             let handles: Vec<_> = ranges
                 .iter()
                 .map(|range| {
                     let source = source.clone();
                     let registry = registry.clone();
                     let range = range.clone();
+                    let scope = &scope;
                     let progress = progress.as_ref().map(|cb| (&progress_count, cb));
-                    scope.spawn(move || {
+                    thread_scope.spawn(move || {
                         parse_partition(
                             source.as_ref(),
                             &registry,
+                            scope,
+                            subscription,
                             batch_size,
                             &range,
                             false,
@@ -215,52 +341,58 @@ pub fn run_shared_parse<S: SeekablePacketSource>(
         })
     };
 
-    // Surface the first error, if any; otherwise collect partition batches.
-    let mut partition_batches: Vec<ProtocolBatches> = Vec::with_capacity(results.len());
+    // Surface the first error, if any; otherwise collect partition outputs.
+    let mut outputs: Vec<HashMap<String, Vec<RecordBatch>>> = Vec::with_capacity(results.len());
     let mut start_ts_us = i64::MAX;
     let mut end_ts_us = i64::MIN;
+    let mut packets_scanned: u64 = 0;
+    let mut complete_scan = true;
     for r in results {
-        let (batches, min_us, max_us) = r?;
-        if min_us != i64::MAX {
-            start_ts_us = start_ts_us.min(min_us);
+        let out = r?;
+        if out.min_us != i64::MAX {
+            start_ts_us = start_ts_us.min(out.min_us);
         }
-        if max_us != i64::MIN {
-            end_ts_us = end_ts_us.max(max_us);
+        if out.max_us != i64::MIN {
+            end_ts_us = end_ts_us.max(out.max_us);
         }
-        partition_batches.push(batches);
+        packets_scanned += out.packets;
+        complete_scan &= !out.capped;
+        outputs.push(out.batches);
     }
     if start_ts_us == i64::MAX {
         start_ts_us = 0;
         end_ts_us = 0;
     }
 
-    // Reorganize: table -> [per-partition Vec<RecordBatch>] (partition/frame order).
-    let mut tables: HashMap<String, Vec<Vec<RecordBatch>>> = HashMap::new();
-    let mut total_frames = 0usize;
-    if let Some(first) = partition_batches.first() {
-        let keys: Vec<String> = first.keys().cloned().collect();
-        for key in keys {
-            let per_partition: Vec<Vec<RecordBatch>> = partition_batches
-                .iter()
-                .map(|pb| pb.get(&key).cloned().unwrap_or_default())
-                .collect();
-            if key == "frames" {
-                total_frames = per_partition
-                    .iter()
-                    .flat_map(|v| v.iter())
-                    .map(|b| b.num_rows())
-                    .sum();
-            }
-            tables.insert(key, per_partition);
-        }
+    // Reorganize: table -> per-partition Vec<RecordBatch> (frame order).
+    let num_partitions = outputs.len();
+    let mut tables_out: HashMap<String, Arc<TableData>> = HashMap::new();
+    let mut rows_built: HashMap<String, usize> = HashMap::new();
+    for table in subscription.tables.keys() {
+        let schema = subscription.table_schema(table).ok_or_else(|| {
+            Error::Query(crate::error::QueryError::Execution(format!(
+                "Unknown table: {table}"
+            )))
+        })?;
+        let partitions: Vec<Vec<RecordBatch>> = outputs
+            .iter_mut()
+            .map(|pb| pb.remove(table).unwrap_or_default())
+            .collect();
+        let data = TableData { schema, partitions };
+        rows_built.insert(table.clone(), data.total_rows());
+        tables_out.insert(table.clone(), Arc::new(data));
     }
 
     Ok(SharedParseState {
-        num_partitions: partition_batches.len(),
-        tables,
-        parse_passes: 1,
-        start_ts_us,
-        end_ts_us,
-        total_frames,
+        tables: tables_out,
+        stats: ParseStats {
+            parse_passes: 1,
+            packets_scanned,
+            partitions: num_partitions,
+            rows_built,
+            start_ts_us,
+            end_ts_us,
+            complete_scan,
+        },
     })
 }

--- a/pcapsql-datafusion/src/query/udf/mod.rs
+++ b/pcapsql-datafusion/src/query/udf/mod.rs
@@ -133,8 +133,7 @@ pub use datetime::{
 
 // Re-export time UDFs
 pub use time::{
-    create_end_time_udf_eager, create_end_time_udf_lazy, create_relative_time_udf,
-    create_start_time_udf,
+    create_end_time_udf, create_relative_time_udf, create_start_time_udf, CaptureTimeRange,
 };
 
 // Re-export histogram UDAFs and UDFs
@@ -269,7 +268,7 @@ pub fn register_histogram_udfs(ctx: &SessionContext) -> Result<(), Error> {
 /// datetime, and histogram UDFs.
 ///
 /// Note: Time UDFs are NOT included here because they require capture metadata.
-/// Use `register_time_udfs_eager()` or `register_time_udfs_lazy()` separately.
+/// Use `register_time_udfs()` separately (it needs the capture time range).
 pub fn register_all_udfs(ctx: &SessionContext) -> Result<(), Error> {
     register_network_udfs(ctx)?;
     register_protocol_udfs(ctx)?;
@@ -279,49 +278,18 @@ pub fn register_all_udfs(ctx: &SessionContext) -> Result<(), Error> {
     Ok(())
 }
 
-/// Register time UDFs with known timestamps (eager mode).
+/// Register the time UDFs bound to a shared [`CaptureTimeRange`].
 ///
-/// Used in in-memory mode where all packets have been loaded and
-/// timestamps are already extracted from the frames table.
-///
-/// # Arguments
-///
-/// * `ctx` - DataFusion session context
-/// * `start_us` - Capture start timestamp (microseconds since epoch)
-/// * `end_us` - Capture end timestamp (microseconds since epoch)
-pub fn register_time_udfs_eager(
+/// The engine widens the range as parse passes observe packets; the UDFs
+/// read it at invocation time, so values are correct for any query whose
+/// execution follows a parse.
+pub fn register_time_udfs(
     ctx: &SessionContext,
-    start_us: i64,
-    end_us: i64,
+    range: std::sync::Arc<CaptureTimeRange>,
 ) -> Result<(), Error> {
-    ctx.register_udf(create_start_time_udf(start_us));
-    ctx.register_udf(create_end_time_udf_eager(end_us));
-    ctx.register_udf(create_relative_time_udf(start_us));
-    Ok(())
-}
-
-/// Register time UDFs with lazy end_time evaluation (streaming mode).
-///
-/// Used in streaming mode where we don't want to scan the entire file
-/// upfront. The `end_time()` function will scan the file on first call
-/// and cache the result.
-///
-/// # Arguments
-///
-/// * `ctx` - DataFusion session context
-/// * `start_us` - Capture start timestamp (microseconds since epoch)
-/// * `end_scan_fn` - Closure that scans for the last packet timestamp
-pub fn register_time_udfs_lazy<F>(
-    ctx: &SessionContext,
-    start_us: i64,
-    end_scan_fn: F,
-) -> Result<(), Error>
-where
-    F: Fn() -> i64 + Send + Sync + 'static,
-{
-    ctx.register_udf(create_start_time_udf(start_us));
-    ctx.register_udf(create_end_time_udf_lazy(end_scan_fn));
-    ctx.register_udf(create_relative_time_udf(start_us));
+    ctx.register_udf(create_start_time_udf(range.clone()));
+    ctx.register_udf(create_end_time_udf(range.clone()));
+    ctx.register_udf(create_relative_time_udf(range));
     Ok(())
 }
 
@@ -360,18 +328,10 @@ mod tests {
     }
 
     #[test]
-    fn test_register_time_udfs_eager() {
+    fn test_register_time_udfs() {
         let ctx = SessionContext::new();
-        let start_us: i64 = 1_704_067_200_000_000;
-        let end_us: i64 = 1_704_153_600_000_000;
-        register_time_udfs_eager(&ctx, start_us, end_us).unwrap();
-    }
-
-    #[test]
-    fn test_register_time_udfs_lazy() {
-        let ctx = SessionContext::new();
-        let start_us: i64 = 1_704_067_200_000_000;
-        let end_us: i64 = 1_704_153_600_000_000;
-        register_time_udfs_lazy(&ctx, start_us, move || end_us).unwrap();
+        let range = std::sync::Arc::new(CaptureTimeRange::new());
+        range.record(1_000_000, 2_000_000);
+        register_time_udfs(&ctx, range).unwrap();
     }
 }

--- a/pcapsql-datafusion/src/query/udf/time.rs
+++ b/pcapsql-datafusion/src/query/udf/time.rs
@@ -1,27 +1,19 @@
-//! Time-related UDFs for capture time analysis.
+//! Time UDFs bound to the capture's observed time range.
 //!
-//! Provides functions for working with packet timestamps relative to capture timing:
+//! `start_time()`, `end_time()` and `relative_time(ts)` read a shared
+//! [`CaptureTimeRange`] at invocation time. The engine widens the range as
+//! parse passes observe packets, so the UDFs return correct values for any
+//! query whose execution follows a parse of the frames it touches — without
+//! requiring an up-front full scan at engine open.
 //!
-//! - `start_time()` - Returns the capture start timestamp
-//! - `end_time()` - Returns the capture end timestamp
-//! - `relative_time(timestamp)` - Returns seconds from capture start as Float64
-//!
-//! ## Example Queries
-//!
-//! ```sql
-//! -- Get capture time range
-//! SELECT start_time(), end_time();
-//!
-//! -- Filter to first 10 seconds of capture
-//! SELECT * FROM tcp WHERE relative_time(timestamp) < 10.0;
-//!
-//! -- Show relative timestamps
-//! SELECT frame_number, relative_time(timestamp) AS rel_time FROM frames;
-//! ```
+//! Until the first parse pass completes, the range is unknown and the UDFs
+//! return the Unix epoch / 0. The boundary-index integration (migration
+//! phase P6) will pre-populate the range at open for indexed sources.
 
 use std::any::Any;
 use std::fmt::Debug;
-use std::sync::{Arc, OnceLock};
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
 
 use arrow::array::{Array, Float64Array, TimestampMicrosecondArray};
 use arrow::datatypes::{DataType, TimeUnit};
@@ -31,32 +23,95 @@ use datafusion::logical_expr::{
     Volatility,
 };
 
+/// The capture's observed `[start, end]` timestamp range (microseconds since
+/// the Unix epoch), widened monotonically as parse passes observe packets.
+#[derive(Debug)]
+pub struct CaptureTimeRange {
+    /// `i64::MAX` sentinel = no packet observed yet.
+    start_us: AtomicI64,
+    /// `i64::MIN` sentinel = no packet observed yet.
+    end_us: AtomicI64,
+}
+
+impl Default for CaptureTimeRange {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CaptureTimeRange {
+    pub fn new() -> Self {
+        Self {
+            start_us: AtomicI64::new(i64::MAX),
+            end_us: AtomicI64::new(i64::MIN),
+        }
+    }
+
+    /// Widen the range with an observed `[start, end]` (microseconds).
+    pub fn record(&self, start_us: i64, end_us: i64) {
+        self.start_us.fetch_min(start_us, Ordering::Relaxed);
+        self.end_us.fetch_max(end_us, Ordering::Relaxed);
+    }
+
+    /// Observed capture start (0 until any packet has been seen).
+    pub fn start_us(&self) -> i64 {
+        match self.start_us.load(Ordering::Relaxed) {
+            i64::MAX => 0,
+            v => v,
+        }
+    }
+
+    /// Observed capture end (0 until any packet has been seen).
+    pub fn end_us(&self) -> i64 {
+        match self.end_us.load(Ordering::Relaxed) {
+            i64::MIN => 0,
+            v => v,
+        }
+    }
+}
+
 // ============================================================================
 // start_time() UDF - Returns capture start timestamp
 // ============================================================================
 
-/// Create the `start_time()` UDF that returns the capture start timestamp.
+/// Create the `start_time()` UDF returning the capture start timestamp.
 ///
 /// # Example
 /// ```sql
 /// SELECT start_time();
 /// ```
-pub fn create_start_time_udf(start_us: i64) -> ScalarUDF {
-    ScalarUDF::new_from_impl(StartTimeUdf::new(start_us))
+pub fn create_start_time_udf(range: Arc<CaptureTimeRange>) -> ScalarUDF {
+    ScalarUDF::new_from_impl(StartTimeUdf::new(range))
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 struct StartTimeUdf {
     signature: Signature,
-    start_timestamp_us: i64,
+    range: Arc<CaptureTimeRange>,
 }
 
 impl StartTimeUdf {
-    fn new(start_us: i64) -> Self {
+    fn new(range: Arc<CaptureTimeRange>) -> Self {
         Self {
             signature: Signature::new(TypeSignature::Nullary, Volatility::Stable),
-            start_timestamp_us: start_us,
+            range,
         }
+    }
+}
+
+// ScalarUDFImpl requires Eq + Hash; identity is the shared range pointer.
+impl PartialEq for StartTimeUdf {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.range, &other.range)
+    }
+}
+
+impl Eq for StartTimeUdf {}
+
+impl std::hash::Hash for StartTimeUdf {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        "StartTimeUdf".hash(state);
+        Arc::as_ptr(&self.range).hash(state);
     }
 }
 
@@ -79,131 +134,58 @@ impl ScalarUDFImpl for StartTimeUdf {
 
     fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
         Ok(ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
-            Some(self.start_timestamp_us),
+            Some(self.range.start_us()),
             None,
         )))
     }
 }
 
 // ============================================================================
-// end_time() UDF - Eager version (timestamp known at registration)
+// end_time() UDF - Returns capture end timestamp
 // ============================================================================
 
-/// Create the `end_time()` UDF with a known end timestamp (eager mode).
+/// Create the `end_time()` UDF returning the capture end timestamp.
 ///
-/// Used in in-memory mode where all packets have been loaded.
-pub fn create_end_time_udf_eager(end_us: i64) -> ScalarUDF {
-    ScalarUDF::new_from_impl(EagerEndTimeUdf::new(end_us))
+/// # Example
+/// ```sql
+/// SELECT end_time();
+/// ```
+pub fn create_end_time_udf(range: Arc<CaptureTimeRange>) -> ScalarUDF {
+    ScalarUDF::new_from_impl(EndTimeUdf::new(range))
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
-struct EagerEndTimeUdf {
+#[derive(Debug)]
+struct EndTimeUdf {
     signature: Signature,
-    end_timestamp_us: i64,
+    range: Arc<CaptureTimeRange>,
 }
 
-impl EagerEndTimeUdf {
-    fn new(end_us: i64) -> Self {
+impl EndTimeUdf {
+    fn new(range: Arc<CaptureTimeRange>) -> Self {
         Self {
             signature: Signature::new(TypeSignature::Nullary, Volatility::Stable),
-            end_timestamp_us: end_us,
+            range,
         }
     }
 }
 
-impl ScalarUDFImpl for EagerEndTimeUdf {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn name(&self) -> &str {
-        "end_time"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
-        Ok(DataType::Timestamp(TimeUnit::Microsecond, None))
-    }
-
-    fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
-        Ok(ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
-            Some(self.end_timestamp_us),
-            None,
-        )))
-    }
-}
-
-// ============================================================================
-// end_time() UDF - Lazy version (scans on first call)
-// ============================================================================
-
-/// Create the `end_time()` UDF with lazy evaluation (streaming mode).
-///
-/// The scan function is called on the first invocation and cached.
-/// This avoids scanning the entire file if end_time() is never called.
-pub fn create_end_time_udf_lazy<F>(scan_fn: F) -> ScalarUDF
-where
-    F: Fn() -> i64 + Send + Sync + 'static,
-{
-    ScalarUDF::new_from_impl(LazyEndTimeUdf::new(scan_fn))
-}
-
-struct LazyEndTimeUdf {
-    signature: Signature,
-    /// Closure that scans for last timestamp (captures Arc<Source>)
-    scan_fn: Arc<dyn Fn() -> i64 + Send + Sync>,
-    /// Cached result (computed on first call)
-    end_ts: OnceLock<i64>,
-}
-
-impl LazyEndTimeUdf {
-    fn new<F>(scan_fn: F) -> Self
-    where
-        F: Fn() -> i64 + Send + Sync + 'static,
-    {
-        Self {
-            signature: Signature::new(TypeSignature::Nullary, Volatility::Stable),
-            scan_fn: Arc::new(scan_fn),
-            end_ts: OnceLock::new(),
-        }
-    }
-
-    fn get_end_timestamp(&self) -> i64 {
-        *self.end_ts.get_or_init(|| (self.scan_fn)())
-    }
-}
-
-impl Debug for LazyEndTimeUdf {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("LazyEndTimeUdf")
-            .field("end_ts", &self.end_ts)
-            .finish()
-    }
-}
-
-// Manual implementations since closures can't be derived
-impl PartialEq for LazyEndTimeUdf {
+// ScalarUDFImpl requires Eq + Hash; identity is the shared range pointer.
+impl PartialEq for EndTimeUdf {
     fn eq(&self, other: &Self) -> bool {
-        // Two LazyEndTimeUdfs are equal if they have the same cached value
-        // (or both are uncached). The closures are considered equivalent.
-        self.end_ts.get() == other.end_ts.get()
+        Arc::ptr_eq(&self.range, &other.range)
     }
 }
 
-impl Eq for LazyEndTimeUdf {}
+impl Eq for EndTimeUdf {}
 
-impl std::hash::Hash for LazyEndTimeUdf {
+impl std::hash::Hash for EndTimeUdf {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        // Hash based on the name and any cached value
-        "LazyEndTimeUdf".hash(state);
-        self.end_ts.get().hash(state);
+        "EndTimeUdf".hash(state);
+        Arc::as_ptr(&self.range).hash(state);
     }
 }
 
-impl ScalarUDFImpl for LazyEndTimeUdf {
+impl ScalarUDFImpl for EndTimeUdf {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -221,9 +203,8 @@ impl ScalarUDFImpl for LazyEndTimeUdf {
     }
 
     fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
-        let end_us = self.get_end_timestamp();
         Ok(ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
-            Some(end_us),
+            Some(self.range.end_us()),
             None,
         )))
     }
@@ -233,32 +214,49 @@ impl ScalarUDFImpl for LazyEndTimeUdf {
 // relative_time(timestamp) UDF - Returns seconds from capture start
 // ============================================================================
 
-/// Create the `relative_time(timestamp)` UDF that returns seconds from capture start.
+/// Create the `relative_time(timestamp)` UDF returning seconds from capture
+/// start.
 ///
 /// # Example
 /// ```sql
 /// SELECT frame_number, relative_time(timestamp) AS rel_time FROM frames;
 /// SELECT * FROM tcp WHERE relative_time(timestamp) < 10.0;
 /// ```
-pub fn create_relative_time_udf(start_us: i64) -> ScalarUDF {
-    ScalarUDF::new_from_impl(RelativeTimeUdf::new(start_us))
+pub fn create_relative_time_udf(range: Arc<CaptureTimeRange>) -> ScalarUDF {
+    ScalarUDF::new_from_impl(RelativeTimeUdf::new(range))
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 struct RelativeTimeUdf {
     signature: Signature,
-    start_timestamp_us: i64,
+    range: Arc<CaptureTimeRange>,
 }
 
 impl RelativeTimeUdf {
-    fn new(start_us: i64) -> Self {
+    fn new(range: Arc<CaptureTimeRange>) -> Self {
         Self {
             signature: Signature::exact(
                 vec![DataType::Timestamp(TimeUnit::Microsecond, None)],
                 Volatility::Stable,
             ),
-            start_timestamp_us: start_us,
+            range,
         }
+    }
+}
+
+// ScalarUDFImpl requires Eq + Hash; identity is the shared range pointer.
+impl PartialEq for RelativeTimeUdf {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.range, &other.range)
+    }
+}
+
+impl Eq for RelativeTimeUdf {}
+
+impl std::hash::Hash for RelativeTimeUdf {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        "RelativeTimeUdf".hash(state);
+        Arc::as_ptr(&self.range).hash(state);
     }
 }
 
@@ -286,7 +284,7 @@ impl ScalarUDFImpl for RelativeTimeUdf {
             .downcast_ref::<TimestampMicrosecondArray>()
             .expect("relative_time: expected timestamp array");
 
-        let start_us = self.start_timestamp_us;
+        let start_us = self.range.start_us();
         let result: Float64Array = timestamps
             .iter()
             .map(|opt| opt.map(|ts| (ts - start_us) as f64 / 1_000_000.0))
@@ -302,11 +300,37 @@ mod tests {
     use arrow::array::TimestampMicrosecondArray;
     use datafusion::prelude::*;
 
+    fn range_with(start_us: i64, end_us: i64) -> Arc<CaptureTimeRange> {
+        let range = Arc::new(CaptureTimeRange::new());
+        range.record(start_us, end_us);
+        range
+    }
+
+    #[test]
+    fn test_range_unknown_defaults_to_epoch() {
+        let range = CaptureTimeRange::new();
+        assert_eq!(range.start_us(), 0);
+        assert_eq!(range.end_us(), 0);
+    }
+
+    #[test]
+    fn test_range_widens_monotonically() {
+        let range = CaptureTimeRange::new();
+        range.record(100, 200);
+        range.record(150, 300);
+        range.record(50, 180);
+        assert_eq!(range.start_us(), 50);
+        assert_eq!(range.end_us(), 300);
+    }
+
     #[tokio::test]
     async fn test_start_time_udf() {
         let ctx = SessionContext::new();
         let start_us: i64 = 1_704_067_200_000_000; // 2024-01-01 00:00:00 UTC
-        ctx.register_udf(create_start_time_udf(start_us));
+        ctx.register_udf(create_start_time_udf(range_with(
+            start_us,
+            start_us + 1_000_000,
+        )));
 
         let result = ctx
             .sql("SELECT start_time()")
@@ -329,10 +353,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_end_time_udf_eager() {
+    async fn test_end_time_udf() {
         let ctx = SessionContext::new();
         let end_us: i64 = 1_704_153_600_000_000; // 2024-01-02 00:00:00 UTC
-        ctx.register_udf(create_end_time_udf_eager(end_us));
+        ctx.register_udf(create_end_time_udf(range_with(end_us - 1_000_000, end_us)));
 
         let result = ctx
             .sql("SELECT end_time()")
@@ -353,20 +377,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_end_time_udf_lazy() {
+    async fn test_end_time_udf_sees_late_updates() {
+        // The range can be populated AFTER registration (a parse pass that
+        // runs between planning and execution) — the UDF must see it.
         let ctx = SessionContext::new();
+        let range = Arc::new(CaptureTimeRange::new());
+        ctx.register_udf(create_end_time_udf(range.clone()));
+
         let end_us: i64 = 1_704_153_600_000_000;
-
-        // Lazy version with closure
-        let scan_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let scan_called_clone = scan_called.clone();
-        ctx.register_udf(create_end_time_udf_lazy(move || {
-            scan_called_clone.store(true, std::sync::atomic::Ordering::SeqCst);
-            end_us
-        }));
-
-        // Scan should not be called until we query
-        assert!(!scan_called.load(std::sync::atomic::Ordering::SeqCst));
+        range.record(end_us - 5_000_000, end_us);
 
         let result = ctx
             .sql("SELECT end_time()")
@@ -376,11 +395,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Now scan should have been called
-        assert!(scan_called.load(std::sync::atomic::Ordering::SeqCst));
-
-        let batch = &result[0];
-        let ts_array = batch
+        let ts_array = result[0]
             .column(0)
             .as_any()
             .downcast_ref::<TimestampMicrosecondArray>()
@@ -392,7 +407,10 @@ mod tests {
     async fn test_relative_time_udf() {
         let ctx = SessionContext::new();
         let start_us: i64 = 1_704_067_200_000_000; // 2024-01-01 00:00:00 UTC
-        ctx.register_udf(create_relative_time_udf(start_us));
+        ctx.register_udf(create_relative_time_udf(range_with(
+            start_us,
+            start_us + 10_000_000,
+        )));
 
         // Create a test table with timestamps
         let timestamps = TimestampMicrosecondArray::from(vec![
@@ -441,7 +459,10 @@ mod tests {
     async fn test_relative_time_filter() {
         let ctx = SessionContext::new();
         let start_us: i64 = 1_704_067_200_000_000;
-        ctx.register_udf(create_relative_time_udf(start_us));
+        ctx.register_udf(create_relative_time_udf(range_with(
+            start_us,
+            start_us + 12_000_000,
+        )));
 
         let timestamps = TimestampMicrosecondArray::from(vec![
             start_us,              // 0.0 seconds

--- a/pcapsql-datafusion/tests/cloud_integration.rs
+++ b/pcapsql-datafusion/tests/cloud_integration.rs
@@ -195,20 +195,22 @@ async fn s3_partition_equivalence_engine_level() {
     let e1 = mk(1).await.expect("engine n=1");
     let e4 = mk(4).await.expect("engine n=4");
 
-    assert_eq!(e1.partition_count(), 1);
-    assert!(
-        e4.partition_count() > 1,
-        "cloud object should be parsed in multiple partitions, got {}",
-        e4.partition_count()
-    );
-
-    // One parse pass for a multi-table query.
+    // One parse pass for a multi-table query, split across partitions.
     let _ = run(
         &e4,
         "SELECT f.frame_number, u.dst_port FROM frames f JOIN udp u USING (frame_number)",
     )
     .await;
-    assert_eq!(e4.parse_pass_count(), 1);
+    let stats = e4.last_parse_stats();
+    assert_eq!(stats.parse_passes, 1);
+    assert!(
+        stats.partitions > 1,
+        "cloud object should be parsed in multiple partitions, got {}",
+        stats.partitions
+    );
+
+    let _ = run(&e1, "SELECT count(*) AS c FROM frames").await;
+    assert_eq!(e1.last_parse_stats().partitions, 1);
 
     for sql in [
         "SELECT count(*) AS c FROM frames",
@@ -251,7 +253,7 @@ async fn s3_small_object_single_partition() {
     .expect("engine");
 
     // Below the RangeRequest size gate -> single partition.
-    assert_eq!(engine.partition_count(), 1);
     let frames = run(&engine, "SELECT count(*) AS c FROM frames").await;
     assert!(frames.contains("50"), "expected 50 frames:\n{frames}");
+    assert_eq!(engine.last_parse_stats().partitions, 1);
 }

--- a/pcapsql-datafusion/tests/engine_shared_parse.rs
+++ b/pcapsql-datafusion/tests/engine_shared_parse.rs
@@ -2,7 +2,7 @@
 //! 1-vs-N partition equivalence at the SQL layer (#9).
 
 use arrow::util::pretty::pretty_format_batches;
-use pcapsql_datafusion::query::{EngineOptions, QueryEngine, SourceSpec};
+use pcapsql_datafusion::query::{EngineOptions, QueryEngine, RetentionPolicy, SourceSpec};
 use pcapsql_testgen::{legacy_pcap, GenPacket, GeneratedCapture, LegacyVariant};
 use tempfile::TempDir;
 
@@ -80,16 +80,8 @@ async fn shared_parse_one_pass_and_partition_equivalence() {
     let e1 = engine(&path, 1).await;
     let e4 = engine(&path, 4).await;
 
-    // Real partition counts are reported.
-    assert_eq!(e1.partition_count(), 1);
-    assert!(
-        e4.partition_count() >= 2,
-        "mmap (SeekCost::Free) should split into multiple partitions, got {}",
-        e4.partition_count()
-    );
-
-    // A view query touching multiple protocol tables performs exactly ONE parse
-    // pass over the file, not one per table (#6).
+    // A query touching multiple protocol tables performs exactly ONE parse
+    // pass over the file, not one per table — the shared-parse invariant.
     let _ = run(
         &e4,
         "SELECT f.frame_number, u.dst_port \
@@ -97,10 +89,29 @@ async fn shared_parse_one_pass_and_partition_equivalence() {
          JOIN ipv4 v USING (frame_number)",
     )
     .await;
+    let stats = e4.last_parse_stats();
     assert_eq!(
-        e4.parse_pass_count(),
-        1,
+        stats.parse_passes, 1,
         "shared parse must perform exactly one pass regardless of tables touched"
+    );
+    assert!(
+        stats.partitions >= 2,
+        "mmap (SeekCost::Free) should split into multiple partitions, got {}",
+        stats.partitions
+    );
+    assert_eq!(stats.rows_built.get("frames"), Some(&60));
+    assert_eq!(stats.rows_built.get("udp"), Some(&60));
+
+    let _ = run(&e1, "SELECT count(*) AS c FROM frames").await;
+    assert_eq!(e1.last_parse_stats().partitions, 1);
+
+    // The default retention (CacheOnTouch) serves repeat queries with no
+    // further parsing.
+    let _ = run(&e4, "SELECT count(*) AS c FROM udp").await;
+    assert_eq!(
+        e4.last_parse_stats().parse_passes,
+        0,
+        "cached tables must not re-parse"
     );
 
     // 1-vs-N partition equivalence at the SQL layer: identical rows, identical
@@ -128,13 +139,65 @@ async fn shared_parse_one_pass_and_partition_equivalence() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn empty_capture_is_rejected() {
-    // A header-only legacy capture with no packets.
+async fn scoped_parse_builds_only_referenced_tables() {
+    // RetentionPolicy::None scopes the parse to the query's tables: a query
+    // over `udp` must materialize only `udp` (its L2/L3 dependencies are
+    // parsed for routing but not built as tables, and unrelated app
+    // protocols like `tls` are never even parsed).
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("cap.pcap");
+    std::fs::write(&path, make_capture(40).bytes).unwrap();
+
+    let engine = QueryEngine::open(
+        SourceSpec::Path(path.clone()),
+        EngineOptions {
+            batch_size: 1000,
+            target_partitions: Some(4),
+            index_stride: Some(4),
+            retention: RetentionPolicy::None,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("build engine");
+
+    let out = run(
+        &engine,
+        "SELECT dst_port FROM udp ORDER BY dst_port LIMIT 1",
+    )
+    .await;
+    assert!(out.contains("53"), "expected udp rows:\n{out}");
+
+    let stats = engine.last_parse_stats();
+    assert_eq!(stats.parse_passes, 1);
+    // Only the referenced table is materialized.
+    let built: Vec<&String> = stats
+        .rows_built
+        .iter()
+        .filter(|(_, n)| **n > 0)
+        .map(|(t, _)| t)
+        .collect();
+    assert_eq!(built, vec![&"udp".to_string()], "scoped to udp only");
+    assert!(
+        !stats.rows_built.contains_key("tcp") && !stats.rows_built.contains_key("tls"),
+        "unreferenced protocols must not be materialized: {:?}",
+        stats.rows_built.keys().collect::<Vec<_>>()
+    );
+
+    // RetentionPolicy::None retains nothing: the next query re-parses.
+    let _ = run(&engine, "SELECT count(*) AS c FROM frames").await;
+    assert_eq!(engine.last_parse_stats().parse_passes, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn empty_capture_yields_zero_rows() {
+    // A header-only legacy capture with no packets is a valid (empty)
+    // capture: open succeeds and queries see zero rows.
     let gc = legacy_pcap(LegacyVariant::LeMicro, 1, 65535, &[]);
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("empty.pcap");
     std::fs::write(&path, gc.bytes).unwrap();
-    let result = QueryEngine::open(
+    let engine = QueryEngine::open(
         SourceSpec::Path(path.clone()),
         EngineOptions {
             batch_size: 1000,
@@ -142,6 +205,8 @@ async fn empty_capture_is_rejected() {
             ..Default::default()
         },
     )
-    .await;
-    assert!(result.is_err(), "empty capture should be rejected");
+    .await
+    .expect("empty capture opens");
+    let out = run(&engine, "SELECT count(*) AS c FROM frames").await;
+    assert!(out.contains("0"), "expected zero frames:\n{out}");
 }

--- a/pcapsql-duckdb/src/vtab/protocol_tables.rs
+++ b/pcapsql-duckdb/src/vtab/protocol_tables.rs
@@ -26,7 +26,7 @@ use parking_lot::Mutex;
 
 use pcapsql_core::{
     default_registry, parse_packet, schema::DataKind, FieldValue, FilePacketReader,
-    FilePacketSource, PacketReader, PacketSource, Protocol, ProtocolRegistry,
+    FilePacketSource, PacketReader, PacketSource, ParseScope, Protocol, ProtocolRegistry,
 };
 
 use crate::duckdb_schema::to_duckdb_type;
@@ -176,7 +176,12 @@ fn func_protocol<T: VTab<InitData = ProtocolInitData, BindData = ProtocolBindDat
         let frame_num = init_data.frame_number.fetch_add(1, Ordering::Relaxed) + 1;
 
         // Parse and check if this packet contains our protocol
-        let results = parse_packet(&init_data.registry, packet.link_type, packet.data);
+        let results = parse_packet(
+            &init_data.registry,
+            packet.link_type,
+            packet.data,
+            &ParseScope::full(),
+        );
 
         for (proto_name, parsed) in &results {
             if *proto_name == bind_data.protocol_name {

--- a/pcapsql-duckdb/src/vtab/read_pcap.rs
+++ b/pcapsql-duckdb/src/vtab/read_pcap.rs
@@ -27,7 +27,7 @@ use parking_lot::Mutex;
 
 use pcapsql_core::{
     default_registry, parse_packet, schema::DataKind, FilePacketReader, FilePacketSource,
-    PacketReader, PacketSource, ParseResult, Protocol, ProtocolRegistry,
+    PacketReader, PacketSource, ParseResult, ParseScope, Protocol, ProtocolRegistry,
 };
 
 use crate::duckdb_schema::to_duckdb_type;
@@ -225,7 +225,12 @@ impl VTab for ReadPcapVTab {
                 row_count += 1;
             } else {
                 // Parse and check if this packet contains our protocol
-                let results = parse_packet(&init_data.registry, packet.link_type, packet.data);
+                let results = parse_packet(
+                    &init_data.registry,
+                    packet.link_type,
+                    packet.data,
+                    &ParseScope::full(),
+                );
 
                 // Add ALL occurrences of the protocol (supports tunneled traffic)
                 for (proto_name, parsed) in &results {


### PR DESCRIPTION
## P2 — Query-scoped parse: the binding move

Phase P2 of `docs/query-scoped-parse-migration.md` (#98). **Parsing moves from engine construction to query time, scoped to what each query references.** The four parse entry points collapse to one. The golden corpus is byte-identical, proving the rewrite is behaviour-preserving. **Closes #86** (filters now reach the parse).

**Core (`pcapsql-core`)**
- `parse_packet` gains a `&ParseScope`; `parse_packet_pruned` / `_projected` / `_pruned_projected` fold into it — one entry point. `ParseScope::full()` or `::for_tables(tables, registry).with_projection(..)` drives protocol pruning (the previously-orphaned `compute_required_protocols`/`should_*` machinery) + per-protocol field projection. `pcapsql-duckdb` call sites updated.

**Engine (`pcapsql-datafusion`)**
- `QueryEngine::query` plans first, harvests each `TableScan`'s projection/filters/fetch from the **optimized** plan into a `ParseSubscription`, runs **one** scoped parse pass, installs the result, then executes. Unrecognized scans fall back to a full parse, so correctness never depends on the harvest.
- **`RetentionPolicy`** per the design's matrix: `None` (one-shot — full pushdown: pruning + column projection + parse-time predicates + LIMIT early-stop, retain nothing) vs `CacheOnTouch` (REPL — cache full-column tables on first touch, so repeat queries parse nothing). CLI selects `None` for `-e`/`-f`, `CacheOnTouch` for the REPL.
- `ProtocolTableProvider` serves from a shared `EngineTables` handle; returns `supports_filters_pushdown = Inexact` for parse-evaluable filters (DataFusion re-checks → a kept row is never wrong). `ProtocolScanExec` gains exact `partition_statistics` (free row counts for join ordering).
- `FilterEvaluator` rewritten: table-scoped, **conservative** (any uncertainty keeps the row), IPv4-as-`u32` aware.
- `NormalizedBatchSet` is subscription-scoped: builders only for subscribed tables/columns; parse-time predicate + per-partition row cap applied before any Arrow materialization.
- Time UDFs read a shared `CaptureTimeRange` the engine widens per pass (replaces the eager/lazy split — no up-front full scan).
- `target_partitions` scales with parse parallelism instead of being pinned to 2; `ParseStats` (passes, packets scanned, partitions, rows-built per table, early-stop) replaces the old counters and drives `--stats`.

**Tests**: golden corpus unchanged · `scoped_parse_builds_only_referenced_tables` (a `udp` query never parses tcp/tls) · cache reuse (repeat query ⇒ `parse_passes == 0`) · 1-vs-N equivalence retained · empty capture opens and yields zero rows. Full gate green (fmt, clippy `-D warnings`, `cargo test --workspace`, s3 check).

Net: +1,470 / −1,498.

---
**Stacked on:** #100 (P1) · **Phase:** P2 of P0–P6 · Closes #86

https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96

---
_Generated by [Claude Code](https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96)_