### PR TITLE
P3 — Streaming execution: bounded memory for one-shot queries

### DIFF
--- a/pcapsql-datafusion/src/query/builders/normalized.rs
+++ b/pcapsql-datafusion/src/query/builders/normalized.rs
@@ -7,6 +7,8 @@
 use std::collections::HashMap;
 
 use arrow::record_batch::RecordBatch;
+use datafusion::error::Result as DFResult;
+use tokio::sync::mpsc::UnboundedSender;
 
 use super::protocol::ProtocolBatchBuilder;
 use crate::error::{Error, QueryError};
@@ -15,10 +17,31 @@ use crate::query::providers::ParseSubscription;
 use pcapsql_core::io::PacketRef;
 use pcapsql_core::ParseResult;
 
+/// Where a table's completed batches go.
+enum BatchSink {
+    /// Accumulate in memory (materialize / cache-fill path).
+    Accumulate(Vec<RecordBatch>),
+    /// Stream to a consumer as batches complete (bounded-memory path).
+    Stream(UnboundedSender<DFResult<RecordBatch>>),
+}
+
+impl BatchSink {
+    fn emit(&mut self, batch: RecordBatch) {
+        match self {
+            BatchSink::Accumulate(v) => v.push(batch),
+            // A closed receiver (query cancelled / completed) just drops the
+            // batch; the producer keeps going and exits when the parse ends.
+            BatchSink::Stream(tx) => {
+                let _ = tx.send(Ok(batch));
+            }
+        }
+    }
+}
+
 /// Per-table build state within one parse pass.
 struct TableSlot {
     builder: ProtocolBatchBuilder,
-    batches: Vec<RecordBatch>,
+    sink: BatchSink,
     predicate: Option<FilterEvaluator>,
     fetch: Option<usize>,
     rows_added: usize,
@@ -47,9 +70,33 @@ pub struct NormalizedBatchSet {
 }
 
 impl NormalizedBatchSet {
-    /// Create builders for exactly the subscribed tables, each over its
-    /// (possibly column-subset) schema.
+    /// Create builders for exactly the subscribed tables (materialize mode:
+    /// completed batches accumulate in memory).
     pub fn new(batch_size: usize, subscription: &ParseSubscription) -> Result<Self, Error> {
+        Self::build(batch_size, subscription, |_| {
+            BatchSink::Accumulate(Vec::new())
+        })
+    }
+
+    /// Create builders that stream each table's completed batches to the
+    /// matching sender (bounded-memory mode). A table without a sender
+    /// accumulates (and is dropped on finish).
+    pub fn new_streaming(
+        batch_size: usize,
+        subscription: &ParseSubscription,
+        senders: &HashMap<String, UnboundedSender<DFResult<RecordBatch>>>,
+    ) -> Result<Self, Error> {
+        Self::build(batch_size, subscription, |name| match senders.get(name) {
+            Some(tx) => BatchSink::Stream(tx.clone()),
+            None => BatchSink::Accumulate(Vec::new()),
+        })
+    }
+
+    fn build(
+        batch_size: usize,
+        subscription: &ParseSubscription,
+        mut sink_for: impl FnMut(&str) -> BatchSink,
+    ) -> Result<Self, Error> {
         let mut slots = HashMap::with_capacity(subscription.tables.len());
         for (name, sub) in &subscription.tables {
             let schema = subscription.table_schema(name).ok_or_else(|| {
@@ -59,7 +106,7 @@ impl NormalizedBatchSet {
                 name.clone(),
                 TableSlot {
                     builder: ProtocolBatchBuilder::with_schema(name.clone(), schema, batch_size),
-                    batches: Vec::new(),
+                    sink: sink_for(name),
                     predicate: sub.predicate.clone(),
                     fetch: sub.fetch,
                     rows_added: 0,
@@ -95,7 +142,7 @@ impl NormalizedBatchSet {
                 );
                 slot.rows_added += 1;
                 if let Some(batch) = slot.builder.try_build()? {
-                    slot.batches.push(batch);
+                    slot.sink.emit(batch);
                 }
             }
         }
@@ -116,7 +163,7 @@ impl NormalizedBatchSet {
                 slot.builder.add_parsed_row(frame_number, result);
                 slot.rows_added += 1;
                 if let Some(batch) = slot.builder.try_build()? {
-                    slot.batches.push(batch);
+                    slot.sink.emit(batch);
                 }
             }
         }
@@ -130,14 +177,21 @@ impl NormalizedBatchSet {
         !self.slots.is_empty() && self.slots.values().all(TableSlot::capped)
     }
 
-    /// Finish building and return the per-table batches.
+    /// Finish building. Flushes each table's final partial batch into its
+    /// sink and returns the accumulated batches per table (empty for tables
+    /// in streaming mode — those went to their channels; the sender is
+    /// dropped here, closing the stream).
     pub fn finish(self) -> Result<HashMap<String, Vec<RecordBatch>>, Error> {
         let mut out = HashMap::with_capacity(self.slots.len());
         for (name, mut slot) in self.slots {
             if let Some(batch) = slot.builder.finish()? {
-                slot.batches.push(batch);
+                slot.sink.emit(batch);
             }
-            out.insert(name, slot.batches);
+            let batches = match slot.sink {
+                BatchSink::Accumulate(v) => v,
+                BatchSink::Stream(_) => Vec::new(),
+            };
+            out.insert(name, batches);
         }
         Ok(out)
     }

--- a/pcapsql-datafusion/src/query/mod.rs
+++ b/pcapsql-datafusion/src/query/mod.rs
@@ -47,9 +47,12 @@ use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::config::ConfigOptions;
 use datafusion::logical_expr::{Expr, LogicalPlan};
 use datafusion::prelude::*;
+use tokio::task::JoinHandle;
 
 use crate::error::{Error, QueryError};
-use crate::query::providers::{run_shared_parse, EngineTables, SharedParseState, TableData};
+use crate::query::providers::{
+    run_shared_parse, EngineTables, PartitionStat, SharedParseState, StreamingHandle, TableData,
+};
 use pcapsql_core::{
     default_registry, FilePacketSource, KeyLog, MmapPacketSource, ProtocolRegistry,
     SeekablePacketSource,
@@ -164,16 +167,54 @@ pub struct QueryEngine {
     /// Capture time range, widened by every parse pass (drives time UDFs).
     time_range: Arc<CaptureTimeRange>,
     retention: RetentionPolicy,
-    /// Runs one scoped parse pass over the engine's source.
-    parse_fn: ParseFn,
+    /// Runs one scoped parse pass over the engine's source (materialize or
+    /// stream).
+    parse_source: Arc<dyn ParseSource>,
     /// Instrumentation for the most recent query.
     last_stats: RwLock<ParseStats>,
     /// Table names this engine registered (the harvest universe).
     known_tables: HashSet<String>,
 }
 
-/// Type-erased scoped parse over the engine's source.
-type ParseFn = Box<dyn Fn(&ParseSubscription) -> Result<SharedParseState, Error> + Send + Sync>;
+/// Type-erased scoped parse over the engine's source: either materialize the
+/// subscribed tables (cache-fill) or stream them (bounded memory).
+trait ParseSource: Send + Sync {
+    fn materialize(&self, sub: &ParseSubscription) -> Result<SharedParseState, Error>;
+    fn stream(&self, sub: &ParseSubscription) -> Result<StreamingHandle, Error>;
+}
+
+/// Binds a concrete seekable source to the parse parameters.
+struct SourceParser<S: SeekablePacketSource> {
+    source: Arc<S>,
+    registry: Arc<ProtocolRegistry>,
+    batch_size: usize,
+    partitions: usize,
+    progress: Option<providers::ProgressFn>,
+}
+
+impl<S: SeekablePacketSource> ParseSource for SourceParser<S> {
+    fn materialize(&self, sub: &ParseSubscription) -> Result<SharedParseState, Error> {
+        run_shared_parse(
+            &self.source,
+            &self.registry,
+            self.batch_size,
+            self.partitions,
+            self.progress.clone(),
+            sub,
+        )
+    }
+
+    fn stream(&self, sub: &ParseSubscription) -> Result<StreamingHandle, Error> {
+        providers::run_streaming_parse(
+            &self.source,
+            &self.registry,
+            self.batch_size,
+            self.partitions,
+            self.progress.clone(),
+            sub,
+        )
+    }
+}
 
 /// What one query needs from one table, harvested from its optimized plan.
 #[derive(Debug, Default)]
@@ -350,21 +391,13 @@ impl QueryEngine {
 
         Self::register_cross_layer_views(&ctx).await?;
 
-        let parse_fn: ParseFn = {
-            let registry = registry.clone();
-            let batch_size = opts.batch_size;
-            let progress = opts.progress.clone();
-            Box::new(move |subscription: &ParseSubscription| {
-                run_shared_parse(
-                    &source,
-                    &registry,
-                    batch_size,
-                    parallelism,
-                    progress.clone(),
-                    subscription,
-                )
-            })
-        };
+        let parse_source: Arc<dyn ParseSource> = Arc::new(SourceParser {
+            source,
+            registry: registry.clone(),
+            batch_size: opts.batch_size,
+            partitions: parallelism,
+            progress: opts.progress.clone(),
+        });
 
         Ok(Self {
             ctx,
@@ -372,7 +405,7 @@ impl QueryEngine {
             tables: engine_tables,
             time_range,
             retention: opts.retention,
-            parse_fn,
+            parse_source,
             last_stats: RwLock::new(ParseStats::default()),
             known_tables,
         })
@@ -396,8 +429,34 @@ impl QueryEngine {
             .map_err(|e| Error::Query(QueryError::from(e)))?;
 
         let needs = harvest_table_needs(&optimized, &self.known_tables)?;
-        let stats = self.prepare_tables(needs)?;
-        *self.last_stats.write().expect("stats lock poisoned") = stats;
+        let subscription = self.build_subscription(needs);
+
+        // CacheOnTouch materializes (so the cache can serve any later query);
+        // RetentionPolicy::None streams (bounded memory) and we fold the
+        // producer stats after execution. An empty subscription means every
+        // referenced table is already cached/pinned — nothing to parse.
+        let streaming = self.retention == RetentionPolicy::None && !subscription.tables.is_empty();
+
+        let mut producers: Vec<JoinHandle<Result<PartitionStat, Error>>> = Vec::new();
+        if subscription.tables.is_empty() {
+            *self.last_stats.write().expect("stats lock poisoned") = ParseStats::default();
+        } else if streaming {
+            let mut handle = self.parse_source.stream(&subscription)?;
+            self.tables.install_streams(&mut handle);
+            producers = std::mem::take(&mut handle.producers);
+            *self.last_stats.write().expect("stats lock poisoned") = ParseStats {
+                parse_passes: 1,
+                partitions: handle.num_partitions,
+                ..Default::default()
+            };
+        } else {
+            let (tables, stats) = self.parse_source.materialize(&subscription)?.into_tables();
+            if stats.packets_scanned > 0 {
+                self.time_range.record(stats.start_ts_us, stats.end_ts_us);
+            }
+            self.tables.install(tables);
+            *self.last_stats.write().expect("stats lock poisoned") = stats;
+        }
 
         let result = async {
             let df = self
@@ -411,18 +470,64 @@ impl QueryEngine {
         }
         .await;
 
+        // Streaming: collect() drove the producers to completion. Await them
+        // to fold statistics and surface any parse error (fail closed).
+        let mut producer_error = None;
+        if !producers.is_empty() {
+            let outcomes = futures::future::join_all(producers).await;
+            let mut stats = ParseStats {
+                parse_passes: 1,
+                partitions: outcomes.len(),
+                complete_scan: true,
+                ..Default::default()
+            };
+            let mut start = i64::MAX;
+            let mut end = i64::MIN;
+            for outcome in outcomes {
+                match outcome {
+                    Ok(Ok(p)) => {
+                        stats.packets_scanned += p.packets;
+                        stats.complete_scan &= !p.capped;
+                        if p.min_us != i64::MAX {
+                            start = start.min(p.min_us);
+                        }
+                        if p.max_us != i64::MIN {
+                            end = end.max(p.max_us);
+                        }
+                        for (t, n) in p.rows_built {
+                            *stats.rows_built.entry(t).or_insert(0) += n;
+                        }
+                    }
+                    Ok(Err(e)) => producer_error = producer_error.or(Some(e)),
+                    Err(join_err) => {
+                        producer_error = producer_error.or(Some(Error::Query(
+                            QueryError::Execution(format!("parse producer panicked: {join_err}")),
+                        )))
+                    }
+                }
+            }
+            if start != i64::MAX {
+                stats.start_ts_us = start;
+                stats.end_ts_us = end;
+                self.time_range.record(start, end);
+            }
+            *self.last_stats.write().expect("stats lock poisoned") = stats;
+        }
+
         if self.retention == RetentionPolicy::None {
             self.tables.clear();
         }
 
-        result
+        match producer_error {
+            Some(e) => Err(e),
+            None => result,
+        }
     }
 
-    /// Run the scoped parse pass covering `needs`, honoring the retention
-    /// policy. Returns the pass statistics (zeroed when fully cache-served).
-    fn prepare_tables(&self, needs: HashMap<String, TableNeeds>) -> Result<ParseStats, Error> {
+    /// Build the parse subscription for a query, honoring the retention policy
+    /// and the pushdown/retention matrix (`docs/query-scoped-parse-migration.md`).
+    fn build_subscription(&self, needs: HashMap<String, TableNeeds>) -> ParseSubscription {
         let mut subscription = ParseSubscription::default();
-
         match self.retention {
             RetentionPolicy::CacheOnTouch => {
                 // Cache entries are full-column and unfiltered, so they can
@@ -461,18 +566,7 @@ impl QueryEngine {
                 }
             }
         }
-
-        if subscription.tables.is_empty() {
-            return Ok(ParseStats::default());
-        }
-
-        let parsed = (self.parse_fn)(&subscription)?;
-        let (tables, stats) = parsed.into_tables();
-        if stats.packets_scanned > 0 {
-            self.time_range.record(stats.start_ts_us, stats.end_ts_us);
-        }
-        self.tables.install(tables);
-        Ok(stats)
+        subscription
     }
 
     /// Instrumentation for the most recent query: parse passes (0 when fully

--- a/pcapsql-datafusion/src/query/providers/mod.rs
+++ b/pcapsql-datafusion/src/query/providers/mod.rs
@@ -22,9 +22,9 @@ mod protocol_provider;
 mod scan_exec;
 mod shared;
 
-pub use protocol_provider::{EngineTables, ProtocolTableProvider};
+pub use protocol_provider::{EngineTables, PreparedTable, ProtocolTableProvider};
 pub use scan_exec::ProtocolScanExec;
 pub use shared::{
-    run_shared_parse, ParseStats, ParseSubscription, ProgressFn, SharedParseState, TableData,
-    TableSubscription,
+    run_shared_parse, run_streaming_parse, ParseStats, ParseSubscription, PartitionStat,
+    ProgressFn, SharedParseState, StreamingHandle, TableData, TableSubscription,
 };

--- a/pcapsql-datafusion/src/query/providers/protocol_provider.rs
+++ b/pcapsql-datafusion/src/query/providers/protocol_provider.rs
@@ -8,9 +8,10 @@
 
 use std::any::Any;
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::common::DataFusionError;
@@ -18,10 +19,36 @@ use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::Result as DFResult;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use datafusion::physical_plan::ExecutionPlan;
+use tokio::sync::mpsc::UnboundedReceiver;
 
-use super::shared::TableData;
+use super::shared::{StreamingHandle, TableData};
 use super::ProtocolScanExec;
 use crate::query::filter::FilterEvaluator;
+
+/// Per-partition batch receivers for a streamed table (taken once at
+/// `execute`).
+pub type PartitionReceivers = Arc<Vec<Mutex<Option<UnboundedReceiver<DFResult<RecordBatch>>>>>>;
+
+/// A table prepared for the current query: either materialized batches
+/// (cached / pinned / `CacheOnTouch`) or per-partition streaming receivers
+/// (`RetentionPolicy::None`).
+pub enum PreparedTable {
+    Batches(Arc<TableData>),
+    Stream {
+        schema: SchemaRef,
+        /// One batch receiver per partition, taken once at `execute`.
+        receivers: PartitionReceivers,
+    },
+}
+
+impl PreparedTable {
+    fn schema(&self) -> SchemaRef {
+        match self {
+            PreparedTable::Batches(d) => d.schema.clone(),
+            PreparedTable::Stream { schema, .. } => schema.clone(),
+        }
+    }
+}
 
 /// The tables currently materialized for query execution.
 ///
@@ -31,9 +58,9 @@ use crate::query::filter::FilterEvaluator;
 /// - `pinned` holds tables installed once at engine open and never cleared
 ///   (the keylog-decrypted `http2` table, until migration phase P4 folds the
 ///   stream pass into the shared parse).
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct EngineTables {
-    current: RwLock<HashMap<String, Arc<TableData>>>,
+    current: RwLock<HashMap<String, Arc<PreparedTable>>>,
     pinned: RwLock<HashMap<String, Arc<TableData>>>,
 }
 
@@ -42,12 +69,36 @@ impl EngineTables {
         Self::default()
     }
 
-    /// Install (or replace) table entries for the current query / cache.
+    /// Install (or replace) materialized table entries for the current query
+    /// or cache.
     pub fn install(&self, tables: HashMap<String, Arc<TableData>>) {
-        self.current
-            .write()
-            .expect("EngineTables lock poisoned")
-            .extend(tables);
+        let mut current = self.current.write().expect("EngineTables lock poisoned");
+        for (name, data) in tables {
+            current.insert(name, Arc::new(PreparedTable::Batches(data)));
+        }
+    }
+
+    /// Install per-partition streaming receivers from an in-flight parse.
+    pub fn install_streams(&self, handle: &mut StreamingHandle) {
+        let mut current = self.current.write().expect("EngineTables lock poisoned");
+        for (name, receivers) in handle.receivers.drain() {
+            let schema = handle
+                .schemas
+                .get(&name)
+                .expect("streaming table schema")
+                .clone();
+            let slots: Vec<Mutex<Option<UnboundedReceiver<DFResult<RecordBatch>>>>> = receivers
+                .into_iter()
+                .map(|rx| Mutex::new(Some(rx)))
+                .collect();
+            current.insert(
+                name,
+                Arc::new(PreparedTable::Stream {
+                    schema,
+                    receivers: Arc::new(slots),
+                }),
+            );
+        }
     }
 
     /// Pin a table for the lifetime of the engine (survives `clear`).
@@ -66,15 +117,15 @@ impl EngineTables {
             .clear();
     }
 
-    /// Fetch a table's data (pinned entries win).
-    pub fn get(&self, name: &str) -> Option<Arc<TableData>> {
+    /// Fetch a table's prepared data (pinned entries win).
+    pub fn get(&self, name: &str) -> Option<Arc<PreparedTable>> {
         if let Some(data) = self
             .pinned
             .read()
             .expect("EngineTables lock poisoned")
             .get(name)
         {
-            return Some(data.clone());
+            return Some(Arc::new(PreparedTable::Batches(data.clone())));
         }
         self.current
             .read()
@@ -148,23 +199,24 @@ impl TableProvider for ProtocolTableProvider {
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        let data = self.tables.get(&self.table_name).ok_or_else(|| {
+        let prepared = self.tables.get(&self.table_name).ok_or_else(|| {
             DataFusionError::Execution(format!(
                 "table '{}' was not prepared for this query; \
                  run queries through QueryEngine::query",
                 self.table_name
             ))
         })?;
+        let data_schema = prepared.schema();
 
-        // `projection` indexes the FULL table schema; the materialized data
-        // may be a column subset. Remap by field name into the data's schema.
+        // `projection` indexes the FULL table schema; the materialized/streamed
+        // data may be a column subset. Remap by field name into that schema.
         let remapped: Option<Vec<usize>> = match projection {
             Some(indices) => Some(
                 indices
                     .iter()
                     .map(|&i| {
                         let name = self.schema.field(i).name();
-                        data.schema.index_of(name).map_err(|_| {
+                        data_schema.index_of(name).map_err(|_| {
                             DataFusionError::Execution(format!(
                                 "column '{}' of table '{}' was not materialized for this query",
                                 name, self.table_name
@@ -175,7 +227,7 @@ impl TableProvider for ProtocolTableProvider {
             ),
             None => {
                 // Full-schema scan: only valid when the data is full-width.
-                if data.schema.fields().len() != self.schema.fields().len() {
+                if data_schema.fields().len() != self.schema.fields().len() {
                     return Err(DataFusionError::Execution(format!(
                         "table '{}' was materialized with a column subset but \
                          scanned without a projection",
@@ -186,12 +238,21 @@ impl TableProvider for ProtocolTableProvider {
             }
         };
 
-        Ok(Arc::new(ProtocolScanExec::new(
-            self.table_name.clone(),
-            data.schema.clone(),
-            Arc::new(data.partitions.clone()),
-            remapped,
-        )))
+        let exec = match prepared.as_ref() {
+            PreparedTable::Batches(data) => ProtocolScanExec::batches(
+                self.table_name.clone(),
+                data.schema.clone(),
+                Arc::new(data.partitions.clone()),
+                remapped,
+            ),
+            PreparedTable::Stream { schema, receivers } => ProtocolScanExec::streaming(
+                self.table_name.clone(),
+                schema.clone(),
+                receivers.clone(),
+                remapped,
+            ),
+        };
+        Ok(Arc::new(exec))
     }
 }
 

--- a/pcapsql-datafusion/src/query/providers/scan_exec.rs
+++ b/pcapsql-datafusion/src/query/providers/scan_exec.rs
@@ -1,13 +1,15 @@
 //! Partition-aware scan execution plan for a protocol table.
 //!
-//! Non-generic: it streams pre-parsed per-partition batches produced by the
-//! shared parse pass. It reports the real partition count in [`PlanProperties`]
-//! and declares output ordering by `frame_number` so cross-partition sort-merge
-//! joins reassemble global order without extra sorting.
+//! Serves a table either from pre-materialized per-partition batches
+//! (`CacheOnTouch` / cached / pinned tables) or from per-partition streaming
+//! receivers fed by a concurrent parse (`RetentionPolicy::None`). Either way
+//! it reports the real partition count and declares `frame_number` output
+//! ordering so cross-partition sort-merge joins reassemble global order
+//! without extra sorting.
 
 use std::any::Any;
 use std::fmt;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use arrow::compute::SortOptions;
 use arrow::datatypes::SchemaRef;
@@ -23,31 +25,84 @@ use datafusion::physical_plan::{
     SendableRecordBatchStream, Statistics,
 };
 use futures::stream;
+use futures::StreamExt;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+/// Per-partition batch receiver, taken once at `execute`.
+type ReceiverSlot = Mutex<Option<UnboundedReceiver<DFResult<RecordBatch>>>>;
+
+/// Where a scan's rows come from.
+enum ScanSource {
+    /// Pre-materialized: one `Vec<RecordBatch>` per partition (frame order).
+    Batches(Arc<Vec<Vec<RecordBatch>>>),
+    /// Streamed: one batch receiver per partition, taken once each.
+    Streams(Arc<Vec<ReceiverSlot>>),
+}
+
+impl ScanSource {
+    fn num_partitions(&self) -> usize {
+        match self {
+            ScanSource::Batches(p) => p.len(),
+            ScanSource::Streams(r) => r.len(),
+        }
+    }
+}
 
 /// Execution plan that emits a protocol table's batches, one DataFusion
 /// partition per parse partition.
 pub struct ProtocolScanExec {
     table_name: String,
-    /// One `Vec<RecordBatch>` per partition (frame order).
-    partitions: Arc<Vec<Vec<RecordBatch>>>,
+    source: ScanSource,
+    /// The materialized data's schema (what the batches/streams carry).
+    data_schema: SchemaRef,
+    /// Output schema after `projection` (a subset of `data_schema`).
     projected_schema: SchemaRef,
     projection: Option<Vec<usize>>,
     properties: PlanProperties,
 }
 
 impl ProtocolScanExec {
-    /// Create a scan over `partitions` (this table's per-partition batches).
-    pub fn new(
+    /// Scan over pre-materialized per-partition batches.
+    pub fn batches(
         table_name: String,
-        schema: SchemaRef,
+        data_schema: SchemaRef,
         partitions: Arc<Vec<Vec<RecordBatch>>>,
         projection: Option<Vec<usize>>,
     ) -> Self {
+        Self::new(
+            table_name,
+            data_schema,
+            ScanSource::Batches(partitions),
+            projection,
+        )
+    }
+
+    /// Scan over per-partition streaming receivers.
+    pub fn streaming(
+        table_name: String,
+        data_schema: SchemaRef,
+        receivers: Arc<Vec<ReceiverSlot>>,
+        projection: Option<Vec<usize>>,
+    ) -> Self {
+        Self::new(
+            table_name,
+            data_schema,
+            ScanSource::Streams(receivers),
+            projection,
+        )
+    }
+
+    fn new(
+        table_name: String,
+        data_schema: SchemaRef,
+        source: ScanSource,
+        projection: Option<Vec<usize>>,
+    ) -> Self {
         let projected_schema = match &projection {
-            Some(idx) => Arc::new(schema.project(idx).expect("valid projection")),
-            None => schema.clone(),
+            Some(idx) => Arc::new(data_schema.project(idx).expect("valid projection")),
+            None => data_schema.clone(),
         };
-        let num_partitions = partitions.len().max(1);
+        let num_partitions = source.num_partitions().max(1);
         let eq_props = Self::compute_equivalence_properties(&projected_schema);
         let properties = PlanProperties::new(
             eq_props,
@@ -57,7 +112,8 @@ impl ProtocolScanExec {
         );
         Self {
             table_name,
-            partitions,
+            source,
+            data_schema,
             projected_schema,
             projection,
             properties,
@@ -80,6 +136,16 @@ impl ProtocolScanExec {
             }
         }
         eq_props
+    }
+
+    /// Project a batch to the output schema (no-op when unprojected).
+    fn project(projection: &Option<Vec<usize>>, batch: RecordBatch) -> DFResult<RecordBatch> {
+        match projection {
+            Some(indices) => batch
+                .project(indices)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None)),
+            None => Ok(batch),
+        }
     }
 }
 
@@ -116,38 +182,63 @@ impl ExecutionPlan for ProtocolScanExec {
         partition: usize,
         _context: Arc<TaskContext>,
     ) -> DFResult<SendableRecordBatchStream> {
-        let batches = self.partitions.get(partition).cloned().unwrap_or_default();
         let projection = self.projection.clone();
-        let iter = batches.into_iter().map(move |batch| match &projection {
-            Some(indices) => batch
-                .project(indices)
-                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None)),
-            None => Ok(batch),
-        });
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            self.projected_schema.clone(),
-            stream::iter(iter),
-        )))
+        match &self.source {
+            ScanSource::Batches(partitions) => {
+                let batches = partitions.get(partition).cloned().unwrap_or_default();
+                let iter = batches
+                    .into_iter()
+                    .map(move |batch| Self::project(&projection, batch));
+                Ok(Box::pin(RecordBatchStreamAdapter::new(
+                    self.projected_schema.clone(),
+                    stream::iter(iter),
+                )))
+            }
+            ScanSource::Streams(receivers) => {
+                let rx = receivers
+                    .get(partition)
+                    .and_then(|slot| slot.lock().expect("receiver lock").take())
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "ProtocolScanExec: stream for table '{}' partition {} \
+                             already consumed (a streamed table must be scanned once)",
+                            self.table_name, partition
+                        ))
+                    })?;
+                let s = stream::unfold(rx, |mut rx| async move {
+                    rx.recv().await.map(|item| (item, rx))
+                })
+                .map(move |item| item.and_then(|b| Self::project(&projection, b)));
+                Ok(Box::pin(RecordBatchStreamAdapter::new(
+                    self.projected_schema.clone(),
+                    s,
+                )))
+            }
+        }
     }
 
     fn partition_statistics(&self, partition: Option<usize>) -> DFResult<Statistics> {
-        // Batches are already materialized: row counts are exact and free,
-        // which lets the optimizer order joins sensibly.
-        let rows: usize = match partition {
-            Some(i) => self
-                .partitions
-                .get(i)
-                .map(|p| p.iter().map(|b| b.num_rows()).sum())
-                .unwrap_or(0),
-            None => self
-                .partitions
-                .iter()
-                .flat_map(|p| p.iter())
-                .map(|b| b.num_rows())
-                .sum(),
+        // Exact only for materialized batches; streamed row counts are not
+        // known until the parse completes.
+        let num_rows = match &self.source {
+            ScanSource::Batches(partitions) => {
+                let rows: usize = match partition {
+                    Some(i) => partitions
+                        .get(i)
+                        .map(|p| p.iter().map(|b| b.num_rows()).sum())
+                        .unwrap_or(0),
+                    None => partitions
+                        .iter()
+                        .flat_map(|p| p.iter())
+                        .map(|b| b.num_rows())
+                        .sum(),
+                };
+                Precision::Exact(rows)
+            }
+            ScanSource::Streams(_) => Precision::Absent,
         };
         Ok(Statistics {
-            num_rows: Precision::Exact(rows),
+            num_rows,
             total_byte_size: Precision::Absent,
             column_statistics: Statistics::unknown_column(&self.projected_schema),
         })
@@ -160,11 +251,15 @@ impl DisplayAs for ProtocolScanExec {
             DisplayFormatType::Default
             | DisplayFormatType::Verbose
             | DisplayFormatType::TreeRender => {
+                let mode = match self.source {
+                    ScanSource::Batches(_) => "batches",
+                    ScanSource::Streams(_) => "stream",
+                };
                 write!(
                     f,
-                    "ProtocolScanExec: table={}, partitions={}",
+                    "ProtocolScanExec: table={}, mode={mode}, partitions={}",
                     self.table_name,
-                    self.partitions.len()
+                    self.source.num_partitions()
                 )
             }
         }
@@ -175,7 +270,8 @@ impl fmt::Debug for ProtocolScanExec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProtocolScanExec")
             .field("table_name", &self.table_name)
-            .field("partitions", &self.partitions.len())
+            .field("partitions", &self.source.num_partitions())
+            .field("data_schema", &self.data_schema)
             .finish()
     }
 }

--- a/pcapsql-datafusion/src/query/providers/shared.rs
+++ b/pcapsql-datafusion/src/query/providers/shared.rs
@@ -17,6 +17,9 @@ use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
+use datafusion::error::Result as DFResult;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+use tokio::task::JoinHandle;
 
 use pcapsql_core::io::PacketRange;
 use pcapsql_core::{
@@ -394,5 +397,153 @@ pub fn run_shared_parse<S: SeekablePacketSource>(
             end_ts_us,
             complete_scan,
         },
+    })
+}
+
+// ============================================================================
+// Streaming parse (RetentionPolicy::None) — bounded-memory pipeline.
+// ============================================================================
+
+/// One partition producer's contribution to the pass statistics.
+pub struct PartitionStat {
+    pub min_us: i64,
+    pub max_us: i64,
+    pub packets: u64,
+    pub capped: bool,
+    pub rows_built: HashMap<String, usize>,
+}
+
+/// Handle to an in-flight streaming parse.
+///
+/// Per subscribed table it holds one batch receiver per partition (in
+/// partition order); `ProtocolScanExec` takes a receiver to serve
+/// `execute(partition)`. The producer join handles are awaited by the engine
+/// after query execution to fold statistics and surface parse errors.
+pub struct StreamingHandle {
+    pub receivers: HashMap<String, Vec<UnboundedReceiver<DFResult<RecordBatch>>>>,
+    pub producers: Vec<JoinHandle<Result<PartitionStat, Error>>>,
+    pub num_partitions: usize,
+    pub schemas: HashMap<String, SchemaRef>,
+}
+
+/// Start one scoped parse pass that **streams** each subscribed table's
+/// batches to per-(table, partition) unbounded channels.
+///
+/// One `spawn_blocking` producer per partition owns its reader and builders
+/// and runs the parse to completion, sending completed batches as they form.
+/// Channels are unbounded, so a producer never blocks on a consumer — the
+/// pass is deadlock-free regardless of how DataFusion drains the tables.
+/// Memory stays bounded when consumers keep pace (the sort-merge-join,
+/// frame-ordered common case) and degrades to buffering a table otherwise.
+pub fn run_streaming_parse<S: SeekablePacketSource>(
+    source: &Arc<S>,
+    registry: &Arc<ProtocolRegistry>,
+    batch_size: usize,
+    target_partitions: usize,
+    progress: Option<ProgressFn>,
+    subscription: &ParseSubscription,
+) -> Result<StreamingHandle, Error> {
+    let scope = Arc::new(subscription.parse_scope(registry));
+    let ranges = decide_ranges(source.as_ref(), target_partitions)?;
+    let single = ranges.len() == 1;
+    let num_partitions = ranges.len();
+    let progress_count = Arc::new(AtomicU64::new(0));
+
+    let table_names: Vec<String> = subscription.tables.keys().cloned().collect();
+    let mut schemas = HashMap::with_capacity(table_names.len());
+    for name in &table_names {
+        let schema = subscription.table_schema(name).ok_or_else(|| {
+            Error::Query(crate::error::QueryError::Execution(format!(
+                "Unknown table: {name}"
+            )))
+        })?;
+        schemas.insert(name.clone(), schema);
+    }
+
+    // receivers[table] = one receiver per partition, in partition order.
+    let mut receivers: HashMap<String, Vec<UnboundedReceiver<DFResult<RecordBatch>>>> = table_names
+        .iter()
+        .map(|n| (n.clone(), Vec::with_capacity(num_partitions)))
+        .collect();
+    let mut producers = Vec::with_capacity(num_partitions);
+
+    for range in ranges {
+        // Per-table channel for this partition.
+        let mut senders = HashMap::with_capacity(table_names.len());
+        for name in &table_names {
+            let (tx, rx) = unbounded_channel::<DFResult<RecordBatch>>();
+            senders.insert(name.clone(), tx);
+            receivers.get_mut(name).expect("receiver slot").push(rx);
+        }
+
+        let source = source.clone();
+        let registry = registry.clone();
+        let scope = scope.clone();
+        let subscription = subscription.clone();
+        let progress = progress.clone();
+        let progress_count = progress_count.clone();
+        let tables: Vec<String> = table_names.clone();
+
+        producers.push(tokio::task::spawn_blocking(move || {
+            let mut reader = if single {
+                source.sequential_reader()?
+            } else {
+                source.reader_at(&range)?
+            };
+            let mut batch_set =
+                NormalizedBatchSet::new_streaming(batch_size, &subscription, &senders)?;
+            let mut min_us = i64::MAX;
+            let mut max_us = i64::MIN;
+            let mut packets: u64 = 0;
+            let mut capped = false;
+
+            loop {
+                let processed = reader.process_packets(1024, |packet| {
+                    let us = packet.timestamp_ns / 1_000;
+                    min_us = min_us.min(us);
+                    max_us = max_us.max(us);
+                    let parsed = parse_packet(&registry, packet.link_type, packet.data, &scope);
+                    batch_set.add_packet_from_ref(packet, &parsed)?;
+                    Ok(())
+                })?;
+                packets += processed as u64;
+                if let Some(cb) = &progress {
+                    let total = progress_count.fetch_add(processed as u64, Ordering::Relaxed)
+                        + processed as u64;
+                    cb(total);
+                }
+                if processed == 0 {
+                    break;
+                }
+                if batch_set.all_capped() {
+                    capped = true;
+                    break;
+                }
+            }
+
+            let rows_built: HashMap<String, usize> = tables
+                .iter()
+                .map(|t| (t.clone(), batch_set.row_count(t)))
+                .collect();
+            // finish() flushes final batches and drops the sink senders; the
+            // remaining `senders` map drops at return, closing the channels.
+            batch_set.finish()?;
+            drop(senders);
+
+            Ok(PartitionStat {
+                min_us,
+                max_us,
+                packets,
+                capped,
+                rows_built,
+            })
+        }));
+    }
+
+    Ok(StreamingHandle {
+        receivers,
+        producers,
+        num_partitions,
+        schemas,
     })
 }

--- a/pcapsql-datafusion/tests/engine_shared_parse.rs
+++ b/pcapsql-datafusion/tests/engine_shared_parse.rs
@@ -210,3 +210,98 @@ async fn empty_capture_yields_zero_rows() {
     let out = run(&engine, "SELECT count(*) AS c FROM frames").await;
     assert!(out.contains("0"), "expected zero frames:\n{out}");
 }
+
+/// Build a streaming (RetentionPolicy::None) engine.
+async fn streaming_engine(path: &std::path::Path, partitions: usize) -> QueryEngine {
+    QueryEngine::open(
+        SourceSpec::Path(path.to_path_buf()),
+        EngineOptions {
+            batch_size: 64,
+            target_partitions: Some(partitions),
+            index_stride: Some(8),
+            retention: RetentionPolicy::None,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("build engine")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn streaming_results_match_materialized() {
+    // The streaming path (None) must produce identical results to the
+    // materialized path (CacheOnTouch), across scans, filters and joins.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("cap.pcap");
+    std::fs::write(&path, make_capture(200).bytes).unwrap();
+
+    let streamed = streaming_engine(&path, 4).await;
+    let materialized = engine(&path, 4).await; // default CacheOnTouch
+
+    for sql in [
+        "SELECT count(*) AS c FROM frames",
+        "SELECT count(*) AS c FROM udp",
+        "SELECT frame_number, length FROM frames ORDER BY frame_number",
+        "SELECT frame_number, src_port, dst_port FROM udp WHERE dst_port = 53 \
+         ORDER BY frame_number",
+        "SELECT f.frame_number, u.src_port FROM frames f \
+         JOIN udp u USING (frame_number) ORDER BY f.frame_number",
+    ] {
+        let s = run(&streamed, sql).await;
+        let m = run(&materialized, sql).await;
+        assert_eq!(s, m, "streaming vs materialized mismatch for: {sql}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn streaming_limit_stops_scan_early() {
+    // A LIMIT pushed to the scan caps each partition and stops the parse
+    // before consuming the whole capture.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("cap.pcap");
+    std::fs::write(&path, make_capture(5000).bytes).unwrap();
+
+    let engine = streaming_engine(&path, 1).await;
+    let out = run(&engine, "SELECT frame_number FROM udp LIMIT 5").await;
+    assert!(out.contains('1'), "expected rows:\n{out}");
+
+    let stats = engine.last_parse_stats();
+    assert!(
+        !stats.complete_scan,
+        "LIMIT should stop the scan early (packets_scanned = {})",
+        stats.packets_scanned
+    );
+    assert!(
+        stats.packets_scanned < 5000,
+        "LIMIT should read far fewer than all packets, read {}",
+        stats.packets_scanned
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn streaming_hash_join_completes_without_deadlock() {
+    // A hash join drains one side fully before the other — the unbounded
+    // exchange must not deadlock (it degrades to buffering). The result must
+    // still match the materialized engine.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("cap.pcap");
+    std::fs::write(&path, make_capture(300).bytes).unwrap();
+
+    let streamed = streaming_engine(&path, 4).await;
+    streamed
+        .context()
+        .state_ref()
+        .write()
+        .config_mut()
+        .options_mut()
+        .optimizer
+        .prefer_hash_join = true;
+
+    let sql = "SELECT f.frame_number, u.dst_port FROM frames f \
+               JOIN udp u USING (frame_number) ORDER BY f.frame_number";
+    let s = run(&streamed, sql).await;
+
+    let materialized = engine(&path, 4).await;
+    let m = run(&materialized, sql).await;
+    assert_eq!(s, m, "hash-join streaming result must match materialized");
+}

--- a/pcapsql-datafusion/tests/golden_corpus.rs
+++ b/pcapsql-datafusion/tests/golden_corpus.rs
@@ -15,7 +15,7 @@
 use std::path::{Path, PathBuf};
 
 use arrow::util::pretty::pretty_format_batches;
-use pcapsql_datafusion::query::{EngineOptions, QueryEngine, SourceSpec};
+use pcapsql_datafusion::query::{EngineOptions, QueryEngine, RetentionPolicy, SourceSpec};
 use pcapsql_testgen::{legacy_pcap, GenPacket, LegacyVariant};
 use tempfile::TempDir;
 
@@ -359,6 +359,20 @@ async fn golden_corpus_matches_snapshots() {
 
     let e2 = engine(&path, 2).await;
     let e1 = engine(&path, 1).await;
+    // One-shot CLI path: RetentionPolicy::None streams rather than
+    // materializes. Its results must be identical.
+    let streamed = QueryEngine::open(
+        SourceSpec::Path(path.clone()),
+        EngineOptions {
+            batch_size: 1000,
+            target_partitions: Some(2),
+            index_stride: Some(4),
+            retention: RetentionPolicy::None,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("build streaming engine");
 
     let mut failures = Vec::new();
     for (name, sql) in CORPUS {
@@ -369,6 +383,12 @@ async fn golden_corpus_matches_snapshots() {
         assert_eq!(
             got, got_p1,
             "{name}: results differ between 1 and 2 partitions"
+        );
+        // Streaming (one-shot) vs materialized (REPL) must agree.
+        let got_stream = run(&streamed, sql).await;
+        assert_eq!(
+            got, got_stream,
+            "{name}: streaming result differs from materialized"
         );
 
         let snap_path = golden_dir().join(format!("{name}.snap"));


### PR DESCRIPTION
## P3 — Streaming execution: bounded memory for one-shot queries

Phase P3 of `docs/query-scoped-parse-migration.md` (#98). `RetentionPolicy::None` now **streams** each subscribed table to DataFusion instead of materializing the whole parsed result first — restoring the bounded-memory contract the docs once (falsely) advertised. The golden corpus is byte-identical **and now asserts streaming ≡ materialized** for every query at 1 and 2 partitions.

**How it works**
- `run_streaming_parse` spawns one `spawn_blocking` producer per partition, each owning its reader/builders and running the scoped parse to completion, sending completed batches to per-(table, partition) **unbounded** tokio channels. Unbounded ⇒ a producer never blocks on a consumer ⇒ **deadlock-free by construction** regardless of how DataFusion drains the tables (hash-join build side, divergent rates); memory stays bounded when consumers keep pace (the frame-ordered SMJ common case) and degrades to buffering a table otherwise — exactly the documented contract.
- `NormalizedBatchSet` gains a `BatchSink` (`Accumulate` | `Stream`): the same routing/predicate/row-cap logic feeds either an in-memory `Vec` or a channel.
- `ProtocolScanExec` serves either pre-materialized batches or a per-partition receiver stream; `QueryEngine::query` installs the streams, runs the plan (producers + consumers concurrent), then **awaits the producers** to fold `ParseStats` and surface any parse error (fail-closed). LIMIT still stops the scan early via the per-partition row cap.
- The engine binds its source to a `ParseSource` trait (`materialize` | `stream`).

**Retention split** (the design's matrix): `None` streams (bounded, retain nothing); `CacheOnTouch` keeps the P2 materialize path because the cache must hold full-column tables to serve any later query. `SharedParseState` is therefore **retained** for the cache path rather than deleted — the matrix is load-bearing, so this is a deliberate, documented reconciliation with the doc's P3 deletion list.

**Tests**: golden corpus runs `None` too and asserts identical results · `streaming_results_match_materialized` · `streaming_limit_stops_scan_early` (`packets_scanned < total`, `complete_scan=false`) · `streaming_hash_join_completes_without_deadlock` (`prefer_hash_join` forced on; result matches materialized). Full gate green (fmt, clippy `-D warnings`, `cargo test --workspace`, s3 check).

Net: +686 / −119.

---
**Stacked on:** #101 (P2) · **Phase:** P3 of P0–P6

https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96

---
_Generated by [Claude Code](https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96)_