### PR TITLE
P4 — Stream analysis is on-demand and query-scoped

### DIFF
--- a/pcapsql-datafusion/src/query/mod.rs
+++ b/pcapsql-datafusion/src/query/mod.rs
@@ -70,6 +70,11 @@ fn default_target_partitions() -> usize {
         .clamp(1, 16)
 }
 
+/// Tables produced by the stream-analysis pass (TCP reassembly / TLS
+/// decryption / HTTP-2) rather than the per-packet parse. They are built
+/// on demand by a single sequential read when a query references them.
+const STREAM_TABLES: &[&str] = &["http2"];
+
 /// Configure DataFusion for SortMergeJoin on frame_number-sorted streams.
 fn create_session_context(target_partitions: usize) -> SessionContext {
     let mut config = ConfigOptions::default();
@@ -181,6 +186,9 @@ pub struct QueryEngine {
 trait ParseSource: Send + Sync {
     fn materialize(&self, sub: &ParseSubscription) -> Result<SharedParseState, Error>;
     fn stream(&self, sub: &ParseSubscription) -> Result<StreamingHandle, Error>;
+    /// Run the stream-analysis pass (one sequential read, single partition):
+    /// TCP reassembly + TLS decryption + HTTP/2, producing the [`STREAM_TABLES`].
+    fn stream_pass(&self) -> Result<HashMap<String, TableData>, Error>;
 }
 
 /// Binds a concrete seekable source to the parse parameters.
@@ -190,6 +198,8 @@ struct SourceParser<S: SeekablePacketSource> {
     batch_size: usize,
     partitions: usize,
     progress: Option<providers::ProgressFn>,
+    /// TLS keylog enabling decrypted HTTP/2 in the stream pass.
+    keylog: Option<Arc<KeyLog>>,
 }
 
 impl<S: SeekablePacketSource> ParseSource for SourceParser<S> {
@@ -213,6 +223,29 @@ impl<S: SeekablePacketSource> ParseSource for SourceParser<S> {
             self.progress.clone(),
             sub,
         )
+    }
+
+    fn stream_pass(&self) -> Result<HashMap<String, TableData>, Error> {
+        // Stream reassembly needs whole-capture sequential order, so this is
+        // always a single sequential read (single partition).
+        let mut builder = stream_tables::StreamTableBuilder::new(self.keylog.clone());
+        let mut reader = self.source.sequential_reader()?;
+        builder.process_reader(&mut reader)?;
+
+        let mut out = HashMap::new();
+        let http2 = builder.http2_batches(self.batch_size)?;
+        let schema = http2
+            .first()
+            .map(|b| b.schema())
+            .unwrap_or_else(|| Arc::new(tables::get_table_schema("http2").expect("http2 schema")));
+        out.insert(
+            "http2".to_string(),
+            TableData {
+                schema,
+                partitions: vec![http2],
+            },
+        );
+        Ok(out)
     }
 }
 
@@ -369,26 +402,6 @@ impl QueryEngine {
             known_tables.insert(table_name.to_string());
         }
 
-        // With a keylog, a sequential stream pass (TCP reassembly + TLS
-        // decryption + HTTP/2) pins the decrypted http2 table. Migration
-        // phase P4 folds this second pass into the scoped parse.
-        if let Some(keylog) = opts.keylog.clone() {
-            let mut stream_builder = stream_tables::StreamTableBuilder::new(Some(keylog));
-            let mut reader = source.sequential_reader()?;
-            stream_builder.process_reader(&mut reader)?;
-            let http2_batches = stream_builder.http2_batches(opts.batch_size)?;
-            if !http2_batches.is_empty() {
-                let schema = http2_batches[0].schema();
-                engine_tables.pin(
-                    "http2".to_string(),
-                    Arc::new(TableData {
-                        schema,
-                        partitions: vec![http2_batches],
-                    }),
-                );
-            }
-        }
-
         Self::register_cross_layer_views(&ctx).await?;
 
         let parse_source: Arc<dyn ParseSource> = Arc::new(SourceParser {
@@ -397,6 +410,7 @@ impl QueryEngine {
             batch_size: opts.batch_size,
             partitions: parallelism,
             progress: opts.progress.clone(),
+            keylog: opts.keylog.clone(),
         });
 
         Ok(Self {
@@ -428,7 +442,35 @@ impl QueryEngine {
             .optimize(&plan)
             .map_err(|e| Error::Query(QueryError::from(e)))?;
 
-        let needs = harvest_table_needs(&optimized, &self.known_tables)?;
+        let mut needs = harvest_table_needs(&optimized, &self.known_tables)?;
+
+        // Stream-analysis tables are produced by the on-demand stream pass,
+        // not the per-packet parse. Split them out and run the pass once if a
+        // referenced stream table isn't already prepared (cached). A query
+        // mixing stream and packet tables runs both passes.
+        let stream_needed: Vec<String> = needs
+            .keys()
+            .filter(|t| STREAM_TABLES.contains(&t.as_str()))
+            .cloned()
+            .collect();
+        for t in &stream_needed {
+            needs.remove(t);
+        }
+        let mut stream_rows: HashMap<String, usize> = HashMap::new();
+        let mut stream_passes = 0usize;
+        if stream_needed.iter().any(|t| !self.tables.contains(t)) {
+            let produced = self.parse_source.stream_pass()?;
+            let installed: HashMap<String, Arc<TableData>> = produced
+                .into_iter()
+                .map(|(name, data)| {
+                    stream_rows.insert(name.clone(), data.total_rows());
+                    (name, Arc::new(data))
+                })
+                .collect();
+            self.tables.install(installed);
+            stream_passes = 1;
+        }
+
         let subscription = self.build_subscription(needs);
 
         // CacheOnTouch materializes (so the cache can serve any later query);
@@ -512,6 +554,15 @@ impl QueryEngine {
                 self.time_range.record(start, end);
             }
             *self.last_stats.write().expect("stats lock poisoned") = stats;
+        }
+
+        // Fold the stream pass into the reported statistics.
+        if stream_passes > 0 {
+            let mut stats = self.last_stats.write().expect("stats lock poisoned");
+            stats.parse_passes += stream_passes;
+            for (t, n) in stream_rows {
+                stats.rows_built.insert(t, n);
+            }
         }
 
         if self.retention == RetentionPolicy::None {

--- a/pcapsql-datafusion/src/query/providers/protocol_provider.rs
+++ b/pcapsql-datafusion/src/query/providers/protocol_provider.rs
@@ -50,18 +50,15 @@ impl PreparedTable {
     }
 }
 
-/// The tables currently materialized for query execution.
+/// The tables prepared for query execution.
 ///
-/// - `current` holds the per-query scoped parse result
-///   (`RetentionPolicy::None`, cleared after each query) or the accumulated
-///   cache (`RetentionPolicy::CacheOnTouch`).
-/// - `pinned` holds tables installed once at engine open and never cleared
-///   (the keylog-decrypted `http2` table, until migration phase P4 folds the
-///   stream pass into the shared parse).
+/// `current` holds the per-query scoped parse result
+/// (`RetentionPolicy::None`, cleared after each query) or the accumulated
+/// cache (`RetentionPolicy::CacheOnTouch`). Stream-analysis tables (`http2`)
+/// are installed here on demand by the stream pass.
 #[derive(Default)]
 pub struct EngineTables {
     current: RwLock<HashMap<String, Arc<PreparedTable>>>,
-    pinned: RwLock<HashMap<String, Arc<TableData>>>,
 }
 
 impl EngineTables {
@@ -101,15 +98,7 @@ impl EngineTables {
         }
     }
 
-    /// Pin a table for the lifetime of the engine (survives `clear`).
-    pub fn pin(&self, name: String, data: Arc<TableData>) {
-        self.pinned
-            .write()
-            .expect("EngineTables lock poisoned")
-            .insert(name, data);
-    }
-
-    /// Drop all non-pinned entries (`RetentionPolicy::None`, post-query).
+    /// Drop all entries (`RetentionPolicy::None`, post-query).
     pub fn clear(&self) {
         self.current
             .write()
@@ -117,16 +106,8 @@ impl EngineTables {
             .clear();
     }
 
-    /// Fetch a table's prepared data (pinned entries win).
+    /// Fetch a table's prepared data.
     pub fn get(&self, name: &str) -> Option<Arc<PreparedTable>> {
-        if let Some(data) = self
-            .pinned
-            .read()
-            .expect("EngineTables lock poisoned")
-            .get(name)
-        {
-            return Some(Arc::new(PreparedTable::Batches(data.clone())));
-        }
         self.current
             .read()
             .expect("EngineTables lock poisoned")
@@ -134,7 +115,7 @@ impl EngineTables {
             .cloned()
     }
 
-    /// Whether the table is already materialized (pinned or current).
+    /// Whether the table is already prepared.
     pub fn contains(&self, name: &str) -> bool {
         self.get(name).is_some()
     }

--- a/pcapsql-datafusion/tests/engine_shared_parse.rs
+++ b/pcapsql-datafusion/tests/engine_shared_parse.rs
@@ -211,6 +211,33 @@ async fn empty_capture_yields_zero_rows() {
     assert!(out.contains("0"), "expected zero frames:\n{out}");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn http2_stream_table_is_on_demand() {
+    // `http2` is produced by the stream-analysis pass, not the packet parse,
+    // and only when a query references it. This capture has no HTTP/2, so the
+    // pass runs and yields an empty table (no error).
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("cap.pcap");
+    std::fs::write(&path, make_capture(50).bytes).unwrap();
+
+    // A query that does NOT reference http2 must not run the stream pass.
+    let e1 = engine(&path, 2).await;
+    let _ = run(&e1, "SELECT count(*) AS c FROM udp").await;
+    assert!(
+        !e1.last_parse_stats().rows_built.contains_key("http2"),
+        "stream pass must not run for a non-stream query"
+    );
+
+    // Referencing http2 runs the stream pass on demand and returns empty.
+    let e2 = engine(&path, 2).await;
+    let out = run(&e2, "SELECT count(*) AS c FROM http2").await;
+    assert!(out.contains('0'), "expected empty http2:\n{out}");
+    assert!(
+        e2.last_parse_stats().rows_built.contains_key("http2"),
+        "querying http2 must run the stream pass"
+    );
+}
+
 /// Build a streaming (RetentionPolicy::None) engine.
 async fn streaming_engine(path: &std::path::Path, partitions: usize) -> QueryEngine {
     QueryEngine::open(


### PR DESCRIPTION
## P4 — Stream analysis is on-demand and query-scoped

Phase P4 of `docs/query-scoped-parse-migration.md` (#98). The keylog / HTTP-2 stream pass moves from an **eager second read at engine open** to an **on-demand, query-scoped** pass: `http2` is built only when a query references it, via a single sequential read (reassembly needs whole-capture order). No stream work happens for queries that don't touch stream tables, and nothing is read at open.

**Changes**
- `ParseSource` gains `stream_pass()`: one sequential read feeding the `StreamManager` (TCP reassembly + TLS decryption + HTTP/2). `SourceParser` carries the keylog.
- `QueryEngine::query` splits harvested needs into stream tables (`STREAM_TABLES`) and packet tables; the stream pass runs once when a referenced stream table isn't already prepared, folding its rows into `ParseStats`. A mixed stream+packet query runs both passes.
- Retention applies uniformly: `CacheOnTouch` caches `http2` after first touch; `None` installs it for the query then clears.

**Deleted**
- The eager keylog second read in `build()` (previously read the whole capture at open whenever a keylog was present, even if `http2` was never queried).
- `EngineTables::pin` / the `pinned` map — `http2` is now an ordinary on-demand `current` entry, so the pin mechanism is gone.

**Deferred (documented follow-up)**: reviving `tcp_connections` / `tls_sessions` / `http_messages` as separate queryable tables needs `StreamManager` `Connection`/session accessors + per-table builders (net-new surface beyond the avoid-work migration); and folding the stream pass's TCP extraction into the packet parse to avoid two reads for mixed stream+packet queries.

**Tests**: `http2_stream_table_is_on_demand` (a non-stream query runs no stream pass; querying `http2` runs it once and returns an empty table on a no-HTTP/2 capture). `e2e_tls_http2` unchanged and green. Full gate: fmt, clippy `-D warnings`, `cargo test --workspace`, s3 check.

---
**Stacked on:** #102 (P3) · **Phase:** P4 of P0–P6

https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96

---
_Generated by [Claude Code](https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96)_