### PR TITLE
P5 — Column-aware caching: heavy columns stay out of the cache

### DIFF
--- a/docs/query-scoped-parse-migration.md
+++ b/docs/query-scoped-parse-migration.md
@@ -411,10 +411,29 @@ entries.
 Gate: standard + golden; keylog end-to-end wall-clock should drop ~2× on
 IO-bound captures (one read, one parse).
 
-### P5 — `raw_data` late materialization
+### P5 — `raw_data` / heavy-column materialization is projection-gated
 
-*Goal: the capture's bytes are never duplicated into Arrow at parse time;
-they are fetched from the source only when a query projects them.*
+*Goal: the capture's bytes are never duplicated into Arrow unless a query
+projects them.*
+
+**Delivered:** the parse-time copy elimination landed in **P2** as a side
+effect of column-scoped building — the frames builder only has a `raw_data`
+builder when `raw_data` is in the subscribed columns, so an unprojected
+`raw_data` is never copied. P5 closes the remaining gap on the
+`CacheOnTouch` (REPL) path: the cache was holding **full** columns on first
+touch (including the huge `raw_data` and unused wide-table columns). P5
+makes the cache **column-aware** — it caches exactly the columns a query
+touches, treats a later subset query as a hit, and re-parses + widens on a
+column miss. So `raw_data` (and any heavy/unused column) stays out of the
+cache until actually selected.
+
+*Deferred (optional):* byte-offset / `BinaryView` zero-copy so that even a
+query that **does** project `raw_data` references the mmap buffer instead of
+copying. This needs reader byte-offset plumbing + per-source range reads +
+a compressed-source fallback; the memory contract above does not depend on
+it, so it is left as a follow-up rather than shipped half-built.
+
+Original plan (superseded by the above):
 
 Changes:
 - `PacketRef` gains `byte_offset: u64` (`io/source.rs:34-48`; the readers

--- a/pcapsql-datafusion/src/query/mod.rs
+++ b/pcapsql-datafusion/src/query/mod.rs
@@ -307,6 +307,43 @@ fn harvest_table_needs(
     Ok(needs)
 }
 
+/// Does a cached column set cover what a query needs?
+///
+/// `cached` is the cached entry's column names (`None` = not cached).
+/// `needed` is the query's projected columns (`None` = all columns).
+fn cache_covers(
+    cached: Option<&std::collections::HashSet<String>>,
+    needed: &Option<HashSet<String>>,
+    table: &str,
+) -> bool {
+    let Some(cached) = cached else {
+        return false; // not cached
+    };
+    match needed {
+        // Needs every column: covered only if the cache is the full table.
+        None => tables::get_table_schema(table)
+            .map(|schema| cached.len() == schema.fields().len())
+            .unwrap_or(false),
+        Some(cols) => cols.iter().all(|c| cached.contains(c)),
+    }
+}
+
+/// Union of a cached column set and a query's needed columns; `None`
+/// (all columns) on either side widens to all.
+fn column_union(
+    cached: Option<std::collections::HashSet<String>>,
+    needed: &Option<HashSet<String>>,
+) -> Option<HashSet<String>> {
+    match (cached, needed) {
+        (_, None) => None,
+        (None, Some(n)) => Some(n.clone()),
+        (Some(mut c), Some(n)) => {
+            c.extend(n.iter().cloned());
+            Some(c)
+        }
+    }
+}
+
 impl QueryEngine {
     /// Open a capture and build the engine.
     ///
@@ -581,14 +618,29 @@ impl QueryEngine {
         let mut subscription = ParseSubscription::default();
         match self.retention {
             RetentionPolicy::CacheOnTouch => {
-                // Cache entries are full-column and unfiltered, so they can
-                // serve any later query; only parse what's missing.
-                for name in needs.into_keys() {
-                    if !self.tables.contains(&name) {
-                        subscription
-                            .tables
-                            .insert(name, TableSubscription::default());
+                // Column-aware cache: cache exactly the columns a query touches
+                // (unfiltered, so reuse stays sound). A later query whose
+                // columns are a subset is a cache hit; one needing more
+                // columns re-parses the UNION and widens the entry. This keeps
+                // heavy/rarely-queried columns (notably frames.raw_data) and
+                // unused wide-table columns out of the cache until selected.
+                for (name, table_needs) in needs {
+                    let cached = self.tables.cached_columns(&name);
+                    let needed = &table_needs.columns;
+                    if cache_covers(cached.as_ref(), needed, &name) {
+                        continue; // subset already cached
                     }
+                    // Subscribe the union of cached and needed columns so the
+                    // rebuilt entry is a superset (no churn / loss).
+                    let columns = column_union(cached, needed);
+                    subscription.tables.insert(
+                        name,
+                        TableSubscription {
+                            columns,
+                            predicate: None,
+                            fetch: None,
+                        },
+                    );
                 }
             }
             RetentionPolicy::None => {

--- a/pcapsql-datafusion/src/query/providers/protocol_provider.rs
+++ b/pcapsql-datafusion/src/query/providers/protocol_provider.rs
@@ -119,6 +119,18 @@ impl EngineTables {
     pub fn contains(&self, name: &str) -> bool {
         self.get(name).is_some()
     }
+
+    /// The column names of a prepared table (`None` if not prepared).
+    pub fn cached_columns(&self, name: &str) -> Option<std::collections::HashSet<String>> {
+        self.get(name).map(|prepared| {
+            prepared
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect()
+        })
+    }
 }
 
 /// Table provider for a single protocol table, serving from [`EngineTables`].

--- a/pcapsql-datafusion/tests/engine_shared_parse.rs
+++ b/pcapsql-datafusion/tests/engine_shared_parse.rs
@@ -212,6 +212,52 @@ async fn empty_capture_yields_zero_rows() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn cache_is_column_aware() {
+    // CacheOnTouch caches exactly the columns a query touches. A later query
+    // whose columns are a subset is a cache hit (no re-parse); one needing a
+    // new column (notably the heavy frames.raw_data) re-parses and widens the
+    // cache. Keeps raw_data out of the cache until actually selected.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("cap.pcap");
+    std::fs::write(&path, make_capture(100).bytes).unwrap();
+
+    let engine = engine(&path, 2).await; // CacheOnTouch
+
+    // First touch: caches frames{length}.
+    let _ = run(&engine, "SELECT length FROM frames ORDER BY length").await;
+    assert_eq!(engine.last_parse_stats().parse_passes, 1);
+
+    // Subset (same column) -> cache hit, no parse.
+    let _ = run(&engine, "SELECT length FROM frames").await;
+    assert_eq!(
+        engine.last_parse_stats().parse_passes,
+        0,
+        "subset of cached columns must be a cache hit"
+    );
+
+    // Needs raw_data, which was NOT cached -> re-parse (widen).
+    let out = run(
+        &engine,
+        "SELECT length(hex(raw_data)) AS n FROM frames ORDER BY n DESC LIMIT 1",
+    )
+    .await;
+    assert!(!out.is_empty());
+    assert_eq!(
+        engine.last_parse_stats().parse_passes,
+        1,
+        "a column not in the cache must trigger a re-parse"
+    );
+
+    // Now raw_data is cached too: the same query is a hit.
+    let _ = run(
+        &engine,
+        "SELECT length(hex(raw_data)) AS n FROM frames ORDER BY n DESC LIMIT 1",
+    )
+    .await;
+    assert_eq!(engine.last_parse_stats().parse_passes, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn http2_stream_table_is_on_demand() {
     // `http2` is produced by the stream-analysis pass, not the packet parse,
     // and only when a query references it. This capture has no HTTP/2, so the


### PR DESCRIPTION
## P5 — Column-aware caching (heavy columns stay out of the cache)

Phase P5 of `docs/query-scoped-parse-migration.md` (#98).

**The `raw_data` parse-time copy was already eliminated in P2** — the frames builder only materializes `raw_data` when it's a subscribed column, so an unprojected `raw_data` is never copied. P5 closes the remaining gap on the **`CacheOnTouch` (REPL) path**, which was caching **full** columns on first touch — pulling the huge `frames.raw_data` and unused wide-table columns into memory even when never selected.

**`CacheOnTouch` is now column-aware:**
- caches exactly the columns a query touches (unfiltered, so reuse stays sound);
- a later query whose columns are a **subset** of a cached entry is a cache hit (no re-parse);
- a query needing a column **not** yet cached re-parses the *union* of cached + needed columns and widens the entry (no churn/loss).

So `raw_data` — and any heavy or rarely-queried column — stays out of the cache until a query actually selects it. `cache_covers`/`column_union` decide hits; `EngineTables::cached_columns` exposes a cached entry's columns. This also benefits wide tables (e.g. `tls` ~40 columns) generally.

**Deferred (optional, documented in the migration doc):** byte-offset / `BinaryView` zero-copy for the case where a query *does* project `raw_data` (reference the mmap buffer instead of copying). It needs reader byte-offset plumbing + per-source range reads + a compressed-source fallback; the memory contract here doesn't depend on it, so it's left as follow-up rather than shipped half-built (per the no-vestigial-code principle).

**Test**: `cache_is_column_aware` — `SELECT length` caches `frames{length}`; the repeat is a hit (0 passes); a `hex(raw_data)` query re-parses (1 pass) and caches `raw_data`; repeating it is then a hit. Golden corpus (run under `CacheOnTouch`) unchanged. Full gate green.

---
**Stacked on:** #103 (P4) · **Phase:** P5 of P0–P6

https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96

---
_Generated by [Claude Code](https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96)_