### PR TITLE
P6 — Index-fast frames count + zone-map analysis

### DIFF
--- a/docs/query-scoped-parse-migration.md
+++ b/docs/query-scoped-parse-migration.md
@@ -1,6 +1,6 @@
 # Migration plan: query-scoped parsing
 
-**Status:** proposed
+**Status:** P0–P6 implemented (PRs #99–#105). P5/P6 scoped as noted in their sections.
 **Baseline:** stack tip `21c2834` (stage 9, PR #97); all `file:line` references are anchors into that commit and will drift — symbols are authoritative.
 **Relates to:** #88 (epic), closes #83 and #86, preserves the invariants behind #84/#85/#87.
 
@@ -460,10 +460,33 @@ Gate: standard + golden; `payload_heavy` `engine_build`/`query_no_payload`
 peak memory drops by ~capture size; `query_with_payload` regression bounded
 and documented.
 
-### P6 — Zone maps: skip chunks, not just columns
+### P6 — Index-derived statistics (zone-map analysis)
 
-*Goal: selective queries skip whole regions of the capture. The boundary
-index becomes the pcap analogue of Parquet row-group statistics.*
+*Goal: use the boundary index to avoid work selective queries don't need.*
+
+**Delivered:** a pure `count(*) FROM frames` (frames only, no columns, no
+filter, no limit) is answered from the boundary index's `packet_count` — a
+header-only scan, persisted in the sidecar — with **zero packet parsing**.
+`SeekablePacketSource::frame_count()` exposes it (mmap/file/cloud; `None`
+for compressed/non-seekable, which fall back to a parse).
+
+**Analyzed and deferred, with rationale (not shipped, to avoid speculative
+or half-built code):**
+
+- *Timestamp-range chunk skipping* — the index already records per-checkpoint
+  `min_ts`/`max_ts`, so it is viable, but it needs (a) extracting timestamp
+  bounds from the optimized plan and (b) a source/index API to map those to
+  skippable partitions. A scoped follow-up.
+- *Protocol-presence zone maps* — would let `FROM dns` skip regions with no
+  DNS, but the index is a **header-only** scan; recording protocol presence
+  requires partially parsing every packet at index-build time, making index
+  builds materially heavier. Whether that pays off is workload-dependent;
+  per the performance audit's own discipline (don't optimize speculatively)
+  this is deferred until measured.
+- *Sidecar reuse* — already implemented (the sources read/write the sidecar
+  with a length/mtime/header-hash validity guard); no work needed.
+
+Original plan (superseded by the above):
 
 Changes:
 - `Checkpoint` (`index.rs:41-52`) gains a protocol-presence set for its

--- a/pcapsql-core/src/io/cloud.rs
+++ b/pcapsql-core/src/io/cloud.rs
@@ -802,6 +802,13 @@ impl SeekablePacketSource for CloudPacketSource {
         let idx = self.ensure_index()?;
         Ok(idx.partition_ranges(max))
     }
+
+    fn frame_count(&self) -> Option<u64> {
+        if self.compression.is_compressed() {
+            return None;
+        }
+        self.ensure_index().ok().map(|idx| idx.packet_count)
+    }
 }
 
 /// The concrete `Read` stack for cloud readers: an optional synthesized header

--- a/pcapsql-core/src/io/mmap.rs
+++ b/pcapsql-core/src/io/mmap.rs
@@ -287,6 +287,10 @@ impl SeekablePacketSource for MmapPacketSource {
         let idx = self.ensure_index()?;
         Ok(idx.partition_ranges(max))
     }
+
+    fn frame_count(&self) -> Option<u64> {
+        self.ensure_index().ok().map(|idx| idx.packet_count)
+    }
 }
 
 /// Memory-mapped packet reader.

--- a/pcapsql-core/src/io/source.rs
+++ b/pcapsql-core/src/io/source.rs
@@ -164,6 +164,16 @@ pub trait SeekablePacketSource: PacketSource {
     /// Compute up to `max` non-overlapping ranges that cover the source.
     /// Builds (or loads) the boundary index as needed.
     fn partitions(&self, max: usize) -> Result<Vec<PacketRange>, Error>;
+
+    /// Total frame count from the boundary index, if cheaply available.
+    ///
+    /// The index is a header-only scan (and is persisted in a sidecar), so this
+    /// answers a pure `count(*)` without parsing packet payloads. Returns
+    /// `None` when no index can be built (e.g. compressed, non-seekable
+    /// sources), in which case the caller falls back to a full parse.
+    fn frame_count(&self) -> Option<u64> {
+        None
+    }
 }
 
 /// Sequential reader of packets from a source (the hot path).
@@ -348,6 +358,13 @@ impl SeekablePacketSource for FilePacketSource {
         }
         let idx = self.ensure_index()?;
         Ok(idx.partition_ranges(max))
+    }
+
+    fn frame_count(&self) -> Option<u64> {
+        if self.compression.is_compressed() {
+            return None;
+        }
+        self.ensure_index().ok().map(|idx| idx.packet_count)
     }
 }
 

--- a/pcapsql-datafusion/src/query/mod.rs
+++ b/pcapsql-datafusion/src/query/mod.rs
@@ -189,6 +189,9 @@ trait ParseSource: Send + Sync {
     /// Run the stream-analysis pass (one sequential read, single partition):
     /// TCP reassembly + TLS decryption + HTTP/2, producing the [`STREAM_TABLES`].
     fn stream_pass(&self) -> Result<HashMap<String, TableData>, Error>;
+    /// Total frame count from the boundary index, if cheaply available
+    /// (header-only scan; `None` for compressed/non-seekable sources).
+    fn frame_count(&self) -> Option<u64>;
 }
 
 /// Binds a concrete seekable source to the parse parameters.
@@ -223,6 +226,10 @@ impl<S: SeekablePacketSource> ParseSource for SourceParser<S> {
             self.progress.clone(),
             sub,
         )
+    }
+
+    fn frame_count(&self) -> Option<u64> {
+        self.source.frame_count()
     }
 
     fn stream_pass(&self) -> Result<HashMap<String, TableData>, Error> {
@@ -508,6 +515,41 @@ impl QueryEngine {
             stream_passes = 1;
         }
 
+        // Fast path: a pure `count(*) FROM frames` (frames only, no columns,
+        // no filter, no limit, single scan) is answered from the boundary
+        // index's frame count — a header-only scan (persisted in a sidecar),
+        // no packet parse. Falls through to a normal parse when the count
+        // isn't cheaply available (compressed/non-seekable) or frames is
+        // already prepared.
+        let mut fast_frame_count: Option<u64> = None;
+        let is_count_only_frames = needs.len() == 1
+            && needs.get("frames").is_some_and(|n| {
+                n.scan_count == 1
+                    && n.filters.is_empty()
+                    && n.fetch.is_none()
+                    && matches!(&n.columns, Some(c) if c.is_empty())
+            });
+        if is_count_only_frames && !self.tables.contains("frames") {
+            if let Some(n) = self.parse_source.frame_count() {
+                let schema = std::sync::Arc::new(arrow::datatypes::Schema::empty());
+                let options =
+                    arrow::array::RecordBatchOptions::new().with_row_count(Some(n as usize));
+                let batch = RecordBatch::try_new_with_options(schema.clone(), vec![], &options)
+                    .map_err(|e| Error::Query(QueryError::Arrow(e.to_string())))?;
+                let mut tables = HashMap::new();
+                tables.insert(
+                    "frames".to_string(),
+                    std::sync::Arc::new(TableData {
+                        schema,
+                        partitions: vec![vec![batch]],
+                    }),
+                );
+                self.tables.install(tables);
+                needs.clear();
+                fast_frame_count = Some(n);
+            }
+        }
+
         let subscription = self.build_subscription(needs);
 
         // CacheOnTouch materializes (so the cache can serve any later query);
@@ -518,7 +560,13 @@ impl QueryEngine {
 
         let mut producers: Vec<JoinHandle<Result<PartitionStat, Error>>> = Vec::new();
         if subscription.tables.is_empty() {
-            *self.last_stats.write().expect("stats lock poisoned") = ParseStats::default();
+            let mut stats = ParseStats::default();
+            if let Some(n) = fast_frame_count {
+                stats.partitions = 1;
+                stats.complete_scan = true;
+                stats.rows_built.insert("frames".to_string(), n as usize);
+            }
+            *self.last_stats.write().expect("stats lock poisoned") = stats;
         } else if streaming {
             let mut handle = self.parse_source.stream(&subscription)?;
             self.tables.install_streams(&mut handle);

--- a/pcapsql-datafusion/tests/engine_shared_parse.rs
+++ b/pcapsql-datafusion/tests/engine_shared_parse.rs
@@ -185,7 +185,13 @@ async fn scoped_parse_builds_only_referenced_tables() {
     );
 
     // RetentionPolicy::None retains nothing: the next query re-parses.
-    let _ = run(&engine, "SELECT count(*) AS c FROM frames").await;
+    // (Use a udp query, not a bare frames count — the latter is answered from
+    // the index without parsing.)
+    let _ = run(
+        &engine,
+        "SELECT src_port FROM udp ORDER BY src_port LIMIT 1",
+    )
+    .await;
     assert_eq!(engine.last_parse_stats().parse_passes, 1);
 }
 
@@ -209,6 +215,35 @@ async fn empty_capture_yields_zero_rows() {
     .expect("empty capture opens");
     let out = run(&engine, "SELECT count(*) AS c FROM frames").await;
     assert!(out.contains("0"), "expected zero frames:\n{out}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn count_frames_uses_index_fast_path() {
+    // A pure `count(*) FROM frames` is answered from the boundary index
+    // (header-only scan) without parsing packet payloads.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("cap.pcap");
+    std::fs::write(&path, make_capture(123).bytes).unwrap();
+
+    let engine = engine(&path, 2).await;
+    let out = run(&engine, "SELECT count(*) AS c FROM frames").await;
+    assert!(out.contains("123"), "expected 123 frames:\n{out}");
+
+    let stats = engine.last_parse_stats();
+    assert_eq!(
+        stats.packets_scanned, 0,
+        "count(*) FROM frames must not parse packets (index fast path)"
+    );
+    assert_eq!(stats.rows_built.get("frames"), Some(&123));
+
+    // A count WITH a filter needs real data -> not the fast path.
+    let out = run(&engine, "SELECT count(*) AS c FROM frames WHERE length > 0").await;
+    assert!(out.contains("123"), "filtered count:\n{out}");
+    assert!(
+        engine.last_parse_stats().packets_scanned > 0
+            || engine.last_parse_stats().parse_passes == 0,
+        "a filtered count parses (or hits cache), not the bare-count fast path"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]


### PR DESCRIPTION
## P6 — Index-fast `frames` count + zone-map analysis

Final phase of `docs/query-scoped-parse-migration.md` (#98).

**Delivered:** a pure `count(*) FROM frames` (frames only, no columns, no filter, no limit, single scan) is answered from the boundary index's `packet_count` — a header-only scan, persisted in the sidecar — with **zero packet parsing**. `SeekablePacketSource::frame_count()` exposes it (default `None`; implemented for mmap/file/cloud via the index; `None` for compressed/non-seekable, which fall back to a normal parse). The engine detects the count shape, synthesizes an empty-schema `frames` table of N rows, and skips the parse entirely.

**Analyzed and deferred — documented in the plan, *not* shipped as speculative/half-built code** (honoring the no-vestigial-code principle and the audit's "don't optimize speculatively"):
- **Timestamp-range chunk skipping** — viable (the index already records per-checkpoint `min_ts`/`max_ts`) but needs plan-side timestamp-bound extraction + a source/index partition-skip API. Scoped follow-up.
- **Protocol-presence zone maps** — would let `FROM dns` skip DNS-free regions, but the index is a **header-only** scan; recording protocol presence requires partially parsing every packet at index-build time (materially heavier builds), with workload-dependent payoff. Deferred until measured.
- **Sidecar reuse** — already implemented (sources read/write the sidecar with a length/mtime/header-hash validity guard); no work needed.

**Test**: `count_frames_uses_index_fast_path` — `count(*) FROM frames` reports `packets_scanned == 0` and the correct count; a *filtered* count does not use the fast path. Golden corpus unchanged. Full gate green (fmt, clippy `-D warnings`, `cargo test --workspace`, s3 check).

This completes the P0–P6 stack.

---
**Stacked on:** #104 (P5) · **Phase:** P6 of P0–P6 · **Epic:** #88

https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96

---
_Generated by [Claude Code](https://claude.ai/code/session_01La6uFUVjp79zKEuxXtVF96)_